### PR TITLE
Failed to recover view fix

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -293,7 +293,7 @@ static int sst_scan_uuid_seqno (const char* str,
   }
 
   WSREP_ERROR("Failed to parse uuid:seqno pair: '%s'", str);
-  return EINVAL;
+  return -EINVAL;
 }
 
 // get rid of trailing \n
@@ -622,7 +622,7 @@ static ssize_t sst_prepare_other (const char*  method,
                  " %s "
                  WSREP_SST_OPT_PARENT " '%d'"
                  " %s '%s'"
-	         " %s '%s'",
+                 " %s '%s'",
                  method, addr_in, mysql_real_data_home,
                  wsrep_defaults_file,
                  (int)getpid(), binlog_opt, binlog_opt_val,
@@ -1032,7 +1032,7 @@ static int sst_flush_tables(THD* thd)
       WSREP_WARN("Current client character set is non-supported parser character set: %s", current_charset->csname);
       thd->variables.character_set_client = &my_charset_latin1;
       WSREP_WARN("For SST temporally setting character set to : %s",
-	      my_charset_latin1.csname);
+                 my_charset_latin1.csname);
   }
 
   if (run_sql_command(thd, "FLUSH TABLES WITH READ LOCK"))
@@ -1134,7 +1134,7 @@ static void sst_disallow_writes (THD* thd, bool yes)
       WSREP_WARN("Current client character set is non-supported parser character set: %s", current_charset->csname);
       thd->variables.character_set_client = &my_charset_latin1;
       WSREP_WARN("For SST temporally setting character set to : %s",
-	      my_charset_latin1.csname);
+                 my_charset_latin1.csname);
   }
 
   snprintf (query_str, query_max, "SET GLOBAL innodb_disallow_writes=%d",
@@ -1167,7 +1167,7 @@ static void* sst_donor_thread (void* a)
                        // operate with wsrep_ready == OFF
   wsp::process proc(arg->cmd, "r", arg->env);
 
-  err= proc.error();
+  err= -proc.error();
 
 /* Inform server about SST script startup and release TO isolation */
   mysql_mutex_lock   (&arg->lock);
@@ -1230,6 +1230,7 @@ wait_signal:
       else
       {
         WSREP_WARN("Received unknown signal: '%s'", out);
+        proc.wait();
       }
     }
     else
@@ -1237,7 +1238,7 @@ wait_signal:
       WSREP_ERROR("Failed to read from: %s", proc.cmd());
       proc.wait();
     }
-    if (!err && proc.error()) err= proc.error();
+    if (!err && proc.error()) err= -proc.error();
   }
   else
   {


### PR DESCRIPTION
This PR deals with messages like
```
2018-12-06 18:51:33 3 [ERROR] WSREP: wsrep_schema::recover_view() failed.
```
which could be unnecessarily logged at least in the following two cases:
 - SST failed (when we don't want to recover view anyways)
 - data wsrep schema is empty (which is a perfectly fine situation on the first node startup)

The first is addressed in a fixed wsrep-lib version. The second in `wsrep_schema::restore_view()`

MTR: https://jenkins.galeracluster.com:8443/job/mtr-galera-4.x-mariadb-10.4/133/consoleFull

apparently it fixes `galera_3nodes.galera_pc_bootstrap` and `galera.galera_log_output_csv`
