### PR TITLE
Fix for MW-284, and other tests which set wsrep_on=OFF

### DIFF
--- a/mysql-test/suite/galera/r/MW-284.result
+++ b/mysql-test/suite/galera/r/MW-284.result
@@ -28,7 +28,7 @@ CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work
 connection node_1;
 set global wsrep_on=OFF;
 RESET MASTER;
-set global wsrep_on=OFF;
+set global wsrep_on=ON;
 CALL mtr.add_suppression('WSREP: Last Applied Action message in non-primary configuration from member');
 connection node_2;
 CALL mtr.add_suppression('WSREP: Last Applied Action message in non-primary configuration from member');

--- a/mysql-test/suite/galera/t/MW-284.test
+++ b/mysql-test/suite/galera/t/MW-284.test
@@ -65,7 +65,7 @@ CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work
 --connection node_1
 set global wsrep_on=OFF;
 RESET MASTER;
-set global wsrep_on=OFF;
+set global wsrep_on=ON;
 CALL mtr.add_suppression('WSREP: Last Applied Action message in non-primary configuration from member');
 
 --connection node_2

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1389,6 +1389,7 @@ bool do_command(THD *thd)
       thd->m_digest= NULL;
 
       return_value= FALSE;
+      wsrep_after_command_before_result(thd);
       goto out;
     }
   }


### PR DESCRIPTION
set global wsrep_on=OFF
RESET MASTER
set global wsrep_on=ON

is usual pattern to enable executing RESET MASTER in active node
but this is wrong pattern, and should be reworked in all tests