### PR TITLE
Fixes for review #1 from svoj

### DIFF
--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -1141,38 +1141,8 @@ bool tdc_remove_table(THD *thd, enum_tdc_remove_table_type remove_type,
     All_share_tables_list::Iterator it(element->all_tables);
     while ((table= it++))
     {
-#ifdef WITH_WSREP
-      if (remove_type == TDC_RT_REMOVE_ALL ||
-          remove_type == TDC_RT_REMOVE_NOT_OWN ||
-          remove_type == TDC_RT_REMOVE_NOT_OWN_KEEP_SHARE)
-      {
-        if (table->in_use != thd)
-        {
-          /*
-            We may end up here if we were granted some MDL
-            lock even if another thd was already granted.
-            In that case we expect their wsrep_conflict_state
-            to be either ABORTING or CERT_FAILURE.
-            See wsrep_grant_mdl_exception()
-          */
-          enum wsrep::transaction::state state=
-            table->in_use->wsrep_trx().state();
-          if (state == wsrep::transaction::s_cert_failed ||
-              state == wsrep::transaction::s_aborting)
-          {
-            WSREP_DEBUG("Table_cache_manager::free_table assert skipped");
-          }
-          else
-          {
-            DBUG_ASSERT(0);
-	  }
-        }
-      }
-      my_refs++;
-#else
       if (table->in_use == thd)
         my_refs++;
-#endif /* WITH_WSREP */
     }
   }
   mysql_mutex_unlock(&element->LOCK_table_share);


### PR DESCRIPTION
The WITH_WSREP block here, in tdc_remove_table() was used to silence the assertion in the use
case where high priority DROP TABLE has BF aborted a blocking local transaction. The victim was
marked to abort asap.
However, this practice has changed, and DROP TABLE will now wait for the victim to abort and release
MDL locks, before continuing. Threfore, the full WITH_WSREP patch has been removed .