### PR TITLE
Fixes for MTR test galera_sr.galera_sr_unit_statements

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_unit_statements.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_unit_statements.result
@@ -1,18 +1,54 @@
+connection node_2;
+connection node_1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION wsrep_trx_fragment_size = 3;
 SET SESSION wsrep_trx_fragment_unit = 'statements';
+connection node_1;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
-INSERT INTO t1 VALUES (2);
+connection node_2;
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
-COUNT(*) = 0
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SELECT COUNT(*) FROM wsrep_schema.SR;
+COUNT(*)
+0
+connection node_1;
+INSERT INTO t1 VALUES (2);
+connection node_2;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+2
+SELECT COUNT(*) FROM wsrep_schema.SR;
+COUNT(*)
 1
+connection node_1;
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
-SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-INSERT INTO t1 VALUES (6);
+connection node_2;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+5
+SELECT COUNT(*) FROM wsrep_schema.SR;
+COUNT(*)
+2
+connection node_1;
 COMMIT;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+5
+SELECT COUNT(*) FROM wsrep_schema.SR;
+COUNT(*)
+0
+connection node_2;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+5
+SELECT COUNT(*) FROM wsrep_schema.SR;
+COUNT(*)
+0
 DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_unit_statements.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_unit_statements.test
@@ -15,33 +15,40 @@ SET SESSION wsrep_trx_fragment_unit = 'statements';
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
+
+# Expect noting is replicated yet, so far we have 2 statements
+--connection node_2
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM wsrep_schema.SR;
+
+--connection node_1
 INSERT INTO t1 VALUES (2);
 
-# The table count on the slave should jump from 0
+# Expect 2 rows in t1 and 1 fragment in SR table
 --connection node_2
---sleep 1
-SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM wsrep_schema.SR;
 
+ --connection node_1
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
 
-# to 3
+# Expect 5 rows in t1 and 2 fragments in SR table
 --connection node_2
-SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
---let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
---source include/wait_condition.inc
-
---connection node_1
-INSERT INTO t1 VALUES (6);
-
-# and then to to 6
---connection node_2
---let $wait_condition = SELECT COUNT(*) = 6 FROM t1;
---source include/wait_condition.inc
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM wsrep_schema.SR;
 
 --connection node_1
 COMMIT;
+
+# Expect 5 rows in t1 and empty SR table
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM wsrep_schema.SR;
+
+--connection node_2
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM wsrep_schema.SR;
 
 DROP TABLE t1;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5516,9 +5516,9 @@ static Sys_var_ulong Sys_wsrep_trx_fragment_size(
       "wsrep_trx_fragment_size",
       "Size of transaction fragments for streaming replication (measured in "
       "units of 'wsrep_trx_fragment_unit')",
-       SESSION_VAR(wsrep_trx_fragment_size), CMD_LINE(REQUIRED_ARG),
-       VALID_RANGE(0, WSREP_MAX_WS_SIZE), DEFAULT(0), BLOCK_SIZE(1),
-       NO_MUTEX_GUARD, NOT_IN_BINLOG,
+      SESSION_VAR(wsrep_trx_fragment_size), CMD_LINE(REQUIRED_ARG),
+      VALID_RANGE(0, WSREP_MAX_WS_SIZE), DEFAULT(0), BLOCK_SIZE(1),
+      NO_MUTEX_GUARD, NOT_IN_BINLOG,
       ON_CHECK(wsrep_trx_fragment_size_check),
       ON_UPDATE(wsrep_trx_fragment_size_update));
 
@@ -5531,7 +5531,9 @@ static Sys_var_enum Sys_wsrep_trx_fragment_unit(
       SESSION_VAR(wsrep_trx_fragment_unit), CMD_LINE(REQUIRED_ARG),
       wsrep_fragment_units,
       DEFAULT(WSREP_FRAG_BYTES),
-      NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0));
+      NO_MUTEX_GUARD, NOT_IN_BINLOG,
+      ON_CHECK(0),
+      ON_UPDATE(wsrep_trx_fragment_unit_update));
 
 extern const char *wsrep_SR_store_types[];
 static Sys_var_enum Sys_wsrep_SR_store(

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -22,6 +22,7 @@
 #include "wsrep_priv.h"
 #include "wsrep_thd.h"
 #include "wsrep_xid.h"
+#include "wsrep_binlog.h" /* wsrep_fragment_unit() */
 #include <my_dir.h>
 #include <cstdio>
 #include <cstdlib>
@@ -673,11 +674,12 @@ bool wsrep_trx_fragment_size_check (sys_var *self, THD* thd, set_var* var)
 
 bool wsrep_trx_fragment_size_update(sys_var* self, THD *thd, enum_var_type)
 {
-  WSREP_INFO("wsrep_trx_fragment_size_update: %lu", thd->variables.wsrep_trx_fragment_size);
+  WSREP_DEBUG("wsrep_trx_fragment_size_update: %lu",
+              thd->variables.wsrep_trx_fragment_size);
   if (thd->variables.wsrep_trx_fragment_size)
   {
     return thd->wsrep_cs().enable_streaming(
-      thd->wsrep_sr().fragment_unit(),
+      wsrep_fragment_unit(thd->variables.wsrep_trx_fragment_unit),
       thd->variables.wsrep_trx_fragment_size);
   }
   else
@@ -685,6 +687,19 @@ bool wsrep_trx_fragment_size_update(sys_var* self, THD *thd, enum_var_type)
     thd->wsrep_cs().disable_streaming();
     return false;
   }
+}
+
+bool wsrep_trx_fragment_unit_update(sys_var* self, THD *thd, enum_var_type)
+{
+  WSREP_DEBUG("wsrep_trx_fragment_unit_update: %lu",
+              thd->variables.wsrep_trx_fragment_unit);
+  if (thd->variables.wsrep_trx_fragment_size)
+  {
+    return thd->wsrep_cs().enable_streaming(
+      wsrep_fragment_unit(thd->variables.wsrep_trx_fragment_unit),
+      thd->variables.wsrep_trx_fragment_size);
+  }
+  return false;
 }
 
 bool wsrep_max_ws_size_check(sys_var *self, THD* thd, set_var* var)

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -93,6 +93,8 @@ extern bool wsrep_desync_update              UPDATE_ARGS;
 extern bool wsrep_trx_fragment_size_check    CHECK_ARGS;
 extern bool wsrep_trx_fragment_size_update   UPDATE_ARGS;
 
+extern bool wsrep_trx_fragment_unit_update   UPDATE_ARGS;
+
 extern bool wsrep_max_ws_size_check          CHECK_ARGS;
 extern bool wsrep_max_ws_size_update         UPDATE_ARGS;
 


### PR DESCRIPTION
Enable streaming replication when wsrep_trx_fragment_unit is updated
and wsrep_trx_fragment_size is greater than 0.

Improvements to the test itself
* Expected counts of replicated rows was wrong because of missing
  switch to connection node_1.
* Added checks for SR table contents
* Removed unnecessary wait conditions (wsrep_sync_wait is enabled)
* Removed unnecessary --sleep 1