### PR TITLE
Fix for MW-286 test

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5130,7 +5130,7 @@ static void innobase_kill_query(handlerton*, THD* thd, enum thd_kill_levels)
 
 	if (trx_t* trx = thd_to_trx(thd)) {
 #ifdef WITH_WSREP
-		bool locked= trx->lock.was_chosen_as_deadlock_victim && (wsrep_on(thd));
+		bool locked= trx->lock.was_chosen_as_wsrep_victim;
 		if (locked) {
 			lock_mutex_exit();
 			trx_mutex_exit(trx);
@@ -18556,8 +18556,7 @@ wsrep_innobase_kill_one_trx(
 	 * which is already marked as BF victim
 	 * lock_sys is held until this vicitm has aborted
 	 */
-	bool was_chosen_as_deadlock_victim= victim_trx->lock.was_chosen_as_deadlock_victim;
-	victim_trx->lock.was_chosen_as_deadlock_victim= TRUE;
+	victim_trx->lock.was_chosen_as_wsrep_victim= TRUE;
 
 	wsrep_thd_UNLOCK(thd);
 	if (wsrep_thd_bf_abort(bf_thd, thd, signal))
@@ -18576,7 +18575,7 @@ wsrep_innobase_kill_one_trx(
 	}
 	else {
 		/* victim was not BF aborted, after all */
-		victim_trx->lock.was_chosen_as_deadlock_victim= was_chosen_as_deadlock_victim;
+		victim_trx->lock.was_chosen_as_wsrep_victim= TRUE;
 	}
 
 	DBUG_RETURN(0);

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -596,6 +596,9 @@ struct trx_lock_t {
 					lock_sys.mutex. Otherwise, this may
 					only be modified by the thread that is
 					serving the running transaction. */
+	bool		was_chosen_as_wsrep_victim;
+					/*!< high priority wsrep thread has
+					marked this trx to abort */
 
 	/** Pre-allocated record locks */
 	struct {

--- a/storage/innobase/trx/trx0roll.cc
+++ b/storage/innobase/trx/trx0roll.cc
@@ -457,6 +457,7 @@ trx_rollback_to_savepoint_for_mysql_low(
 	    trx->lock.was_chosen_as_deadlock_victim) {
 		trx->lock.was_chosen_as_deadlock_victim = FALSE;
 	}
+	trx->lock.was_chosen_as_wsrep_victim = FALSE;
 #endif
 	return(err);
 }

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1448,6 +1448,7 @@ trx_commit_in_memory(
 	if (trx->mysql_thd && wsrep_on(trx->mysql_thd)) {
 		trx->lock.was_chosen_as_deadlock_victim = FALSE;
 	}
+	trx->lock.was_chosen_as_wsrep_victim = FALSE;
 #endif
 
 	DBUG_LOG("trx", "Commit in memory: " << trx);


### PR DESCRIPTION
This patch will fix BF aborting of native threads, e.g. threads which have declared
wsrep_on=OFF.
Earlier, we have used, for innodb trx locks, was_chosen_as_deadlock_victim
flag, for marking inodb transactions, which are victims for wsrep BF abort.
With native threads (wsrep_on==OFF), re-using was_chosen_as_deadlock_victim flag may lead
to inteference with real deadlock, and to deal with this, the patch has added new
flag for marking wsrep BF aborts only: was_chosen_as_wsrep_victim