### PR TITLE
Fix for galera.versioning_trx_id test

### DIFF
--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -183,9 +183,9 @@ int wsrep_apply_events(THD*        thd,
     /* Use the original server id for logging. */
     thd->set_server_id(ev->server_id);
     thd->set_time();                            // time the query
+    thd->transaction.start_time.reset(thd);
     //#define mariadb_10_4_0
 #ifdef mariadb_10_4_0
-    thd->transaction.start_time.reset(thd);
     wsrep_xid_init(&thd->transaction.xid_state.xid,
                    thd->wsrep_trx_meta.gtid.uuid,
                    thd->wsrep_trx_meta.gtid.seqno);


### PR DESCRIPTION
Initializing transaction start time for applier THD, this time value will be used to
populate begin_timestamp in mysql.transaction_registry table for the applied transaction