### PR TITLE
Cleaned up obsolete code from service_wsrep.h

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -18,45 +18,7 @@
 #include <my_pthread.h>
 #ifdef __cplusplus
 #endif
-enum wsrep_conflict_state {
-    NO_CONFLICT,
-    MUST_ABORT,
-    ABORTING,
-    ABORTED,
-    MUST_REPLAY,
-    REPLAYING,
-    RETRY_AUTOCOMMIT,
-    CERT_FAILURE,
-};
 
-enum wsrep_exec_mode {
-    /* Transaction processing before replication. */
-    LOCAL_STATE,
-    /* Slave thread applying write sets from other nodes or replaying thread. */
-    REPL_RECV,
-    /* Total-order-isolation mode. */
-    TOTAL_ORDER,
-    /*
-      Transaction procession after it has been replicated in prepare stage and
-      has passed certification.
-    */
-    LOCAL_COMMIT,
-    LOCAL_ROLLBACK,
-};
-
-enum wsrep_query_state {
-    QUERY_IDLE,
-    QUERY_EXEC,
-    QUERY_COMMITTING,
-    QUERY_EXITING,
-};
-
-enum wsrep_trx_status {
-    WSREP_TRX_OK,
-    WSREP_TRX_CERT_FAIL,      /* certification failure, must abort */
-    WSREP_TRX_SIZE_EXCEEDED,  /* trx size exceeded */
-    WSREP_TRX_ERROR,          /* native mysql error */
-};
 struct xid_t;
 struct wsrep_ws_handle;
 struct wsrep_buf;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -142,8 +142,6 @@ extern const char* wsrep_provider_vendor;
 extern char*       wsrep_provider_capabilities;
 extern char*       wsrep_cluster_capabilities;
 
-//int  wsrep_show_status(THD *thd, SHOW_VAR *var, char *buff,
-//                       enum enum_var_type scope);
 int  wsrep_show_status(THD *thd, SHOW_VAR *var, char *buff);
 int  wsrep_show_ready(THD *thd, SHOW_VAR *var, char *buff);
 void wsrep_free_status(THD *thd);
@@ -277,34 +275,8 @@ extern wsrep_seqno_t wsrep_locked_seqno;
 extern my_bool wsrep_ready_get();
 extern void wsrep_ready_wait();
 
-#ifdef OUT
-enum wsrep_trx_status {
-    WSREP_TRX_OK,
-    WSREP_TRX_CERT_FAIL,      /* certification failure, must abort */
-    WSREP_TRX_SIZE_EXCEEDED,  /* trx size exceeded */
-    WSREP_TRX_ERROR,          /* native mysql error */
-};
-#endif
-static inline
-wsrep_status_t wsrep_trx_status_to_wsrep_status(wsrep_trx_status status)
-{
-  switch (status)
-  {
-  case WSREP_TRX_OK:
-    return WSREP_OK;
-  case WSREP_TRX_CERT_FAIL:
-  case WSREP_TRX_ERROR:
-    return WSREP_TRX_FAIL;
-  case WSREP_TRX_SIZE_EXCEEDED:
-    return WSREP_SIZE_EXCEEDED;
-  }
-  return WSREP_NOT_IMPLEMENTED;
-}
-
 class Ha_trx_info;
 struct THD_TRANS;
-
-//extern "C" bool wsrep_consistency_check(void *thd_ptr);
 
 extern mysql_mutex_t LOCK_wsrep_ready;
 extern mysql_cond_t  COND_wsrep_ready;


### PR DESCRIPTION
The following enums are obsoloted by wsrep-lib and should no longer
be exposed: wsrep_conflict_state, wsrep_exec_mode, wsrep_query_state,
wsrep_trx_state.

Removed the enums from service_wsrep.h and cleaned up corresponding
dead code from wsrep_mysqld.h.