### PR TITLE
References codership/mariaDB-wsrep#69 Server-side support

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -194,8 +194,8 @@ extern "C" my_bool wsrep_thd_is_aborting(const void*);
 enum Wsrep_key_type
 {
     wsrep_key_shared,
-    wsrep_key_semi_shared,
-    wsrep_key_semi_exclusive,
+    wsrep_key_reference,
+    wsrep_key_update,
     wsrep_key_exclusive
 };
 struct wsrep_key;

--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -191,19 +191,19 @@ extern "C" my_bool wsrep_thd_skip_locking(const void*);
 extern "C" my_bool wsrep_thd_is_aborting(const void*);
 
 
-enum Wsrep_key_type
+enum Wsrep_service_key_type
 {
-    wsrep_key_shared,
-    wsrep_key_reference,
-    wsrep_key_update,
-    wsrep_key_exclusive
+    WSREP_SERVICE_KEY_SHARED,
+    WSREP_SERVICE_KEY_REFERENCE,
+    WSREP_SERVICE_KEY_UPDATE,
+    WSREP_SERVICE_KEY_EXCLUSIVE
 };
 struct wsrep_key;
 struct wsrep_key_array;
 extern "C" int wsrep_thd_append_key(void*,
                                     const struct wsrep_key* key,
                                     int n_keys,
-                                    enum Wsrep_key_type);
+                                    enum Wsrep_service_key_type);
 #ifdef __cplusplus
 #include <string>
 extern const std::string sr_table_name_full_str;

--- a/mysql-test/suite/galera/r/MW-369.result
+++ b/mysql-test/suite/galera/r/MW-369.result
@@ -1,20 +1,20 @@
 connection node_2;
 connection node_1;
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
+CREATE TABLE pa (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE ca (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pa (f1))  ;
+INSERT INTO pa VALUES (1, 0);
+INSERT INTO pa VALUES (2, 0);
 connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-DELETE FROM p WHERE f1 = 1;
+DELETE FROM pa WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-INSERT INTO c VALUES (1, 1);
+INSERT INTO ca VALUES (1, 1);
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -31,32 +31,32 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM p;
+SELECT * FROM pa;
 f1	f2
 1	0
 2	0
-SELECT * FROM c;
+SELECT * FROM ca;
 f1	p_id
 1	1
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE ca;
+DROP TABLE pa;
 connection node_1;
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CREATE TABLE pb (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cb (f1 INTEGER PRIMARY KEY, p_id INTEGER,
 f2 INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1, 0);
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pb (f1));
+INSERT INTO pb VALUES (1, 0);
+INSERT INTO pb VALUES (2, 0);
+INSERT INTO cb VALUES (1, 1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE p SET f2 = 1 WHERE f1 = 1;
+UPDATE pb SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-UPDATE c SET f2 = 1 WHERE f1 = 1;
+UPDATE cb SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -72,31 +72,31 @@ SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 connection node_2;
-SELECT * FROM p;
+SELECT * FROM pb;
 f1	f2
 1	1
 2	0
-SELECT * FROM c;
+SELECT * FROM cb;
 f1	p_id	f2
 1	1	1
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE cb;
+DROP TABLE pb;
 connection node_1;
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1);
+CREATE TABLE pc (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cc (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pc (f1))  ;
+INSERT INTO pc VALUES (1, 0);
+INSERT INTO pc VALUES (2, 0);
+INSERT INTO cc VALUES (1, 1);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE p SET f2 = 1 WHERE f1 = 1;
+UPDATE pc SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-DELETE FROM c WHERE f1 = 1;
+DELETE FROM cc WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -112,27 +112,27 @@ SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 connection node_2;
-SELECT * FROM p;
+SELECT * FROM pc;
 f1	f2
 1	1
 2	0
-SELECT * FROM c;
+SELECT * FROM cc;
 f1	p_id
-DROP TABLE c;
-DROP TABLE p;
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f2))  ;
-INSERT INTO p VALUES (1, 0);
+DROP TABLE cc;
+DROP TABLE pc;
+CREATE TABLE pd (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
+CREATE TABLE cd (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pd (f2))  ;
+INSERT INTO pd VALUES (1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE p SET f2 = 1 WHERE f1 = 1;
+UPDATE pd SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-INSERT INTO c VALUES (1, 0);;
+INSERT INTO cd VALUES (1, 0);;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -149,30 +149,30 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM p;
+SELECT * FROM pd;
 f1	f2
 1	0
-SELECT * FROM c;
+SELECT * FROM cd;
 f1	p_id
 1	0
-DROP TABLE c;
-DROP TABLE p;
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1)
+DROP TABLE cd;
+DROP TABLE pd;
+CREATE TABLE pe (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE ce (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pe (f1)
 ON DELETE CASCADE)  ;
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1, 0);
+INSERT INTO pe VALUES (1, 0);
+INSERT INTO pe VALUES (2, 0);
+INSERT INTO ce VALUES (1, 1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-DELETE FROM p WHERE f1 = 1;
+DELETE FROM pe WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-UPDATE c SET f2 = 1 WHERE f1 = 1;
+UPDATE ce SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -189,12 +189,93 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM p;
+SELECT * FROM pe;
 f1	f2
 1	0
 2	0
-SELECT * FROM c;
+SELECT * FROM ce;
 f1	p_id	f2
 1	1	1
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE ce;
+DROP TABLE pe;
+connection node_1;
+CREATE TABLE pf (f1 INTEGER PRIMARY KEY) ENGINE=INNODB;
+CREATE TABLE cf (
+f1 INTEGER PRIMARY KEY,
+p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pf (f1)
+);
+INSERT INTO pf VALUES (1);
+connection node_1;
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+INSERT INTO cf (f1, p_id) VALUES (10, 1);
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+connection node_2;
+INSERT INTO cf (f1, p_id) VALUES (20, 1);
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,local_monitor_master_enter_sync';
+connection node_1;
+COMMIT;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+connection node_1;
+connection node_2;
+SELECT * FROM pf;
+f1
+1
+SELECT * FROM cf;
+f1	p_id
+10	1
+20	1
+DROP TABLE cf;
+DROP TABLE pf;
+connection node_1;
+CREATE TABLE pg (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cg (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+f2 INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pg (f1))  ;
+INSERT INTO pg VALUES (1, 0);
+INSERT INTO pg VALUES (2, 0);
+connection node_1;
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+UPDATE pg SET f2 = 1 WHERE f1 = 1;
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+connection node_2;
+INSERT INTO cg VALUES (1, 1, 0);
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,local_monitor_master_enter_sync';
+connection node_1;
+COMMIT;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+connection node_1;
+connection node_2;
+SELECT * FROM pg;
+f1	f2
+1	1
+2	0
+SELECT * FROM cg;
+f1	p_id	f2
+1	1	0
+DROP TABLE cg;
+DROP TABLE pg;

--- a/mysql-test/suite/galera/r/MW-369.result
+++ b/mysql-test/suite/galera/r/MW-369.result
@@ -1,20 +1,20 @@
 connection node_2;
 connection node_1;
-CREATE TABLE pa (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE ca (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pa (f1))  ;
-INSERT INTO pa VALUES (1, 0);
-INSERT INTO pa VALUES (2, 0);
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
 connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-DELETE FROM pa WHERE f1 = 1;
+DELETE FROM p WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-INSERT INTO ca VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -31,32 +31,32 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM pa;
+SELECT * FROM p;
 f1	f2
 1	0
 2	0
-SELECT * FROM ca;
+SELECT * FROM c;
 f1	p_id
 1	1
-DROP TABLE ca;
-DROP TABLE pa;
+DROP TABLE c;
+DROP TABLE p;
 connection node_1;
-CREATE TABLE pb (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE cb (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
 f2 INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pb (f1));
-INSERT INTO pb VALUES (1, 0);
-INSERT INTO pb VALUES (2, 0);
-INSERT INTO cb VALUES (1, 1, 0);
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE pb SET f2 = 1 WHERE f1 = 1;
+UPDATE p SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-UPDATE cb SET f2 = 1 WHERE f1 = 1;
+UPDATE c SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -72,31 +72,31 @@ SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 connection node_2;
-SELECT * FROM pb;
+SELECT * FROM p;
 f1	f2
 1	1
 2	0
-SELECT * FROM cb;
+SELECT * FROM c;
 f1	p_id	f2
 1	1	1
-DROP TABLE cb;
-DROP TABLE pb;
+DROP TABLE c;
+DROP TABLE p;
 connection node_1;
-CREATE TABLE pc (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE cc (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pc (f1))  ;
-INSERT INTO pc VALUES (1, 0);
-INSERT INTO pc VALUES (2, 0);
-INSERT INTO cc VALUES (1, 1);
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE pc SET f2 = 1 WHERE f1 = 1;
+UPDATE p SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-DELETE FROM cc WHERE f1 = 1;
+DELETE FROM c WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -112,27 +112,27 @@ SET GLOBAL wsrep_provider_options = 'signal=local_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 connection node_2;
-SELECT * FROM pc;
+SELECT * FROM p;
 f1	f2
 1	1
 2	0
-SELECT * FROM cc;
+SELECT * FROM c;
 f1	p_id
-DROP TABLE cc;
-DROP TABLE pc;
-CREATE TABLE pd (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
-CREATE TABLE cd (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pd (f2))  ;
-INSERT INTO pd VALUES (1, 0);
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f2))  ;
+INSERT INTO p VALUES (1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-UPDATE pd SET f2 = 1 WHERE f1 = 1;
+UPDATE p SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-INSERT INTO cd VALUES (1, 0);;
+INSERT INTO c VALUES (1, 0);;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -149,30 +149,30 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM pd;
+SELECT * FROM p;
 f1	f2
 1	0
-SELECT * FROM cd;
+SELECT * FROM c;
 f1	p_id
 1	0
-DROP TABLE cd;
-DROP TABLE pd;
-CREATE TABLE pe (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE ce (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
-CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pe (f1)
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1)
 ON DELETE CASCADE)  ;
-INSERT INTO pe VALUES (1, 0);
-INSERT INTO pe VALUES (2, 0);
-INSERT INTO ce VALUES (1, 1, 0);
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1, 0);
 connection node_1;
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-DELETE FROM pe WHERE f1 = 1;
+DELETE FROM p WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
 connection node_2;
-UPDATE ce SET f2 = 1 WHERE f1 = 1;
+UPDATE c SET f2 = 1 WHERE f1 = 1;
 connection node_1a;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
@@ -189,15 +189,18 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 connection node_2;
-SELECT * FROM pe;
+SELECT * FROM p;
 f1	f2
 1	0
 2	0
-SELECT * FROM ce;
+SELECT * FROM c;
 f1	p_id	f2
 1	1	1
-DROP TABLE ce;
-DROP TABLE pe;
+DROP TABLE c;
+DROP TABLE p;
+#
+# Start of 10.4 tests
+#
 connection node_1;
 CREATE TABLE pf (f1 INTEGER PRIMARY KEY) ENGINE=INNODB;
 CREATE TABLE cf (

--- a/mysql-test/suite/galera/t/MW-369.inc
+++ b/mysql-test/suite/galera/t/MW-369.inc
@@ -24,6 +24,7 @@
 --connection node_1
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
+
 --eval $mw_369_parent_query
 
 #

--- a/mysql-test/suite/galera/t/MW-369.inc
+++ b/mysql-test/suite/galera/t/MW-369.inc
@@ -24,7 +24,6 @@
 --connection node_1
 SET AUTOCOMMIT=ON;
 START TRANSACTION;
-
 --eval $mw_369_parent_query
 
 #

--- a/mysql-test/suite/galera/t/MW-369.test
+++ b/mysql-test/suite/galera/t/MW-369.test
@@ -7,8 +7,8 @@
 # another node while the transaction which tries to delete a
 # referred row from the parent table is committing.
 #
-# The pa table will originally have rows (1, 0), (2, 0).
-# The ca table will be empty.
+# The p table will originally have rows (1, 0), (2, 0).
+# The c table will be empty.
 #
 # A new row (1, 1) pointing to parent row (1, 0) is inserted from
 # connection node_2, the transaction which tries to remove the
@@ -25,15 +25,15 @@
 --source include/have_innodb.inc
 --source include/have_debug_sync.inc
 
-CREATE TABLE pa (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE ca (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pa (f1))  ;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
 
-INSERT INTO pa VALUES (1, 0);
-INSERT INTO pa VALUES (2, 0);
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
 
---let $mw_369_parent_query = DELETE FROM pa WHERE f1 = 1
---let $mw_369_child_query = INSERT INTO ca VALUES (1, 1)
+--let $mw_369_parent_query = DELETE FROM p WHERE f1 = 1
+--let $mw_369_child_query = INSERT INTO c VALUES (1, 1)
 
 #
 # we must open connection node_1a here, MW-369.inc will use it later
@@ -47,11 +47,11 @@ INSERT INTO pa VALUES (2, 0);
 --reap
 
 --connection node_2
-SELECT * FROM pa;
-SELECT * FROM ca;
+SELECT * FROM p;
+SELECT * FROM c;
 
-DROP TABLE ca;
-DROP TABLE pa;
+DROP TABLE c;
+DROP TABLE p;
 
 #
 # Test B Outline:
@@ -61,8 +61,8 @@ DROP TABLE pa;
 # child table row is updated concurrently from another node
 # with a transaction which updates the parent table.
 #
-# The pb table will originally have rows (1, 0), (2, 0).
-# The cb table will originally have rows (1, 1, 0) which points
+# The p table will originally have rows (1, 0), (2, 0).
+# The c table will originally have rows (1, 1, 0) which points
 # to parent table row (1, 0).
 #
 # Expected outcome:
@@ -74,17 +74,17 @@ DROP TABLE pa;
 #
 
 --connection node_1
-CREATE TABLE pb (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE cb (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                 f2 INTEGER,
-                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pb (f1));
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                f2 INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
 
-INSERT INTO pb VALUES (1, 0);
-INSERT INTO pb VALUES (2, 0);
-INSERT INTO cb VALUES (1, 1, 0);
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1, 0);
 
---let mw_369_parent_query = UPDATE pb SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = UPDATE cb SET f2 = 1 WHERE f1 = 1
+--let mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = UPDATE c SET f2 = 1 WHERE f1 = 1
 --source MW-369.inc
 
 # Commit succeeds
@@ -92,11 +92,11 @@ INSERT INTO cb VALUES (1, 1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM pb;
-SELECT * FROM cb;
+SELECT * FROM p;
+SELECT * FROM c;
 
-DROP TABLE cb;
-DROP TABLE pb;
+DROP TABLE c;
+DROP TABLE p;
 
 #
 # Test C Outline:
@@ -106,8 +106,8 @@ DROP TABLE pb;
 # deleted concurrently from the other node while a transaction updates
 # the parent table referred by the child table row.
 #
-# The pc table will originally have rows (1, 0), (2, 0)
-# The cc table will originally have row (1, 1) which points to parent
+# The p table will originally have rows (1, 0), (2, 0)
+# The c table will originally have row (1, 1) which points to parent
 # table row (1, 0).
 #
 # A row (1, 1) pointing to parent row (1, 0) is deleted from
@@ -121,16 +121,16 @@ DROP TABLE pb;
 # table should be empty.
 
 --connection node_1
-CREATE TABLE pc (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE cc (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pc (f1))  ;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
 
-INSERT INTO pc VALUES (1, 0);
-INSERT INTO pc VALUES (2, 0);
-INSERT INTO cc VALUES (1, 1);
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1);
 
---let $mw_369_parent_query = UPDATE pc SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = DELETE FROM cc WHERE f1 = 1
+--let $mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = DELETE FROM c WHERE f1 = 1
 --source MW-369.inc
 
 # Commit succeeds
@@ -138,11 +138,11 @@ INSERT INTO cc VALUES (1, 1);
 --reap
 
 --connection node_2
-SELECT * FROM pc;
-SELECT * FROM cc;
+SELECT * FROM p;
+SELECT * FROM c;
 
-DROP TABLE cc;
-DROP TABLE pc;
+DROP TABLE c;
+DROP TABLE p;
 
 
 #
@@ -155,8 +155,8 @@ DROP TABLE pc;
 # but this key value is changed so that insert on node 2 will cause FK
 # violation
 #
-# The pd table will originally have rows (1, 0)
-# The cd table will originally be empty
+# The p table will originally have rows (1, 0)
+# The c table will originally be empty 
 #
 # in node_1, parent row is updated to value (1,1)
 # A row (1, 0) pointing to the old version of parent row (1, 0) is inserted
@@ -164,20 +164,20 @@ DROP TABLE pc;
 #
 # Expected Outcome:
 # ================
-# This is a true conflict and one transaciton must abort. In this case it is
-# node_1 transaction, which was scheduled later.
+# This is a true conflict and one transaciton must abort. In this case it is node_1
+# transaction, which was scheduled later.
 #    Parent table should have row (1,0)
 #    child table should have row (1,0)
 #
 
-CREATE TABLE pd (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
-CREATE TABLE cd (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pd (f2))  ;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f2))  ;
 
-INSERT INTO pd VALUES (1, 0);
+INSERT INTO p VALUES (1, 0);
 
---let $mw_369_parent_query = UPDATE pd SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = INSERT INTO cd VALUES (1, 0);
+--let $mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = INSERT INTO c VALUES (1, 0);
 --source MW-369.inc
 
 # Commit fails
@@ -186,11 +186,11 @@ INSERT INTO pd VALUES (1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM pd;
-SELECT * FROM cd;
+SELECT * FROM p;
+SELECT * FROM c;
 
-DROP TABLE cd;
-DROP TABLE pd;
+DROP TABLE c;
+DROP TABLE p;
 
 #
 # Test E Outline:
@@ -202,8 +202,8 @@ DROP TABLE pd;
 # cascade a delete on child row as well. This will cause true conflict with 
 # connection node_2, which tries to update unrelated column on child table.
 #
-# The pe table will originally have rows (1, 0), (2,0)
-# The ce table will originally have row (1,1,0)
+# The p table will originally have rows (1, 0), (2,0)
+# The c table will originally have row (1,1,0)
 #
 # in node_1, parent row (1,0) is deleted and cascaded delete will happen on
 # child table row (1,1,0).
@@ -218,17 +218,17 @@ DROP TABLE pd;
 #
 
 
-CREATE TABLE pe (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE ce (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
-                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pe (f1)
-                 ON DELETE CASCADE)  ;
+CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1)
+                ON DELETE CASCADE)  ;
 
-INSERT INTO pe VALUES (1, 0);
-INSERT INTO pe VALUES (2, 0);
-INSERT INTO ce VALUES (1, 1, 0);
+INSERT INTO p VALUES (1, 0);
+INSERT INTO p VALUES (2, 0);
+INSERT INTO c VALUES (1, 1, 0);
 
---let $mw_369_parent_query = DELETE FROM pe WHERE f1 = 1
---let $mw_369_child_query = UPDATE ce SET f2 = 1 WHERE f1 = 1
+--let $mw_369_parent_query = DELETE FROM p WHERE f1 = 1
+--let $mw_369_child_query = UPDATE c SET f2 = 1 WHERE f1 = 1
 --source MW-369.inc
 
 # Commit fails
@@ -237,12 +237,15 @@ INSERT INTO ce VALUES (1, 1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM pe;
-SELECT * FROM ce;
+SELECT * FROM p;
+SELECT * FROM c;
 
-DROP TABLE ce;
-DROP TABLE pe;
+DROP TABLE c;
+DROP TABLE p;
 
+--echo #
+--echo # Start of 10.4 tests
+--echo #
 #
 # Test F Outline:
 # ===============

--- a/mysql-test/suite/galera/t/MW-369.test
+++ b/mysql-test/suite/galera/t/MW-369.test
@@ -7,8 +7,8 @@
 # another node while the transaction which tries to delete a
 # referred row from the parent table is committing.
 #
-# The p table will originally have rows (1, 0), (2, 0).
-# The c table will be empty.
+# The pa table will originally have rows (1, 0), (2, 0).
+# The ca table will be empty.
 #
 # A new row (1, 1) pointing to parent row (1, 0) is inserted from
 # connection node_2, the transaction which tries to remove the
@@ -25,15 +25,15 @@
 --source include/have_innodb.inc
 --source include/have_debug_sync.inc
 
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+CREATE TABLE pa (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE ca (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pa (f1))  ;
 
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
+INSERT INTO pa VALUES (1, 0);
+INSERT INTO pa VALUES (2, 0);
 
---let $mw_369_parent_query = DELETE FROM p WHERE f1 = 1
---let $mw_369_child_query = INSERT INTO c VALUES (1, 1)
+--let $mw_369_parent_query = DELETE FROM pa WHERE f1 = 1
+--let $mw_369_child_query = INSERT INTO ca VALUES (1, 1)
 
 #
 # we must open connection node_1a here, MW-369.inc will use it later
@@ -47,11 +47,11 @@ INSERT INTO p VALUES (2, 0);
 --reap
 
 --connection node_2
-SELECT * FROM p;
-SELECT * FROM c;
+SELECT * FROM pa;
+SELECT * FROM ca;
 
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE ca;
+DROP TABLE pa;
 
 #
 # Test B Outline:
@@ -61,8 +61,8 @@ DROP TABLE p;
 # child table row is updated concurrently from another node
 # with a transaction which updates the parent table.
 #
-# The p table will originally have rows (1, 0), (2, 0).
-# The c table will originally have rows (1, 1, 0) which points
+# The pb table will originally have rows (1, 0), (2, 0).
+# The cb table will originally have rows (1, 1, 0) which points
 # to parent table row (1, 0).
 #
 # Expected outcome:
@@ -74,17 +74,17 @@ DROP TABLE p;
 #
 
 --connection node_1
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                f2 INTEGER,
-                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+CREATE TABLE pb (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cb (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                 f2 INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pb (f1));
 
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1, 0);
+INSERT INTO pb VALUES (1, 0);
+INSERT INTO pb VALUES (2, 0);
+INSERT INTO cb VALUES (1, 1, 0);
 
---let mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = UPDATE c SET f2 = 1 WHERE f1 = 1
+--let mw_369_parent_query = UPDATE pb SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = UPDATE cb SET f2 = 1 WHERE f1 = 1
 --source MW-369.inc
 
 # Commit succeeds
@@ -92,11 +92,11 @@ INSERT INTO c VALUES (1, 1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM p;
-SELECT * FROM c;
+SELECT * FROM pb;
+SELECT * FROM cb;
 
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE cb;
+DROP TABLE pb;
 
 #
 # Test C Outline:
@@ -106,8 +106,8 @@ DROP TABLE p;
 # deleted concurrently from the other node while a transaction updates
 # the parent table referred by the child table row.
 #
-# The p table will originally have rows (1, 0), (2, 0)
-# The c table will originally have row (1, 1) which points to parent
+# The pc table will originally have rows (1, 0), (2, 0)
+# The cc table will originally have row (1, 1) which points to parent
 # table row (1, 0).
 #
 # A row (1, 1) pointing to parent row (1, 0) is deleted from
@@ -121,16 +121,16 @@ DROP TABLE p;
 # table should be empty.
 
 --connection node_1
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1))  ;
+CREATE TABLE pc (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cc (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pc (f1))  ;
 
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1);
+INSERT INTO pc VALUES (1, 0);
+INSERT INTO pc VALUES (2, 0);
+INSERT INTO cc VALUES (1, 1);
 
---let $mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = DELETE FROM c WHERE f1 = 1
+--let $mw_369_parent_query = UPDATE pc SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = DELETE FROM cc WHERE f1 = 1
 --source MW-369.inc
 
 # Commit succeeds
@@ -138,11 +138,11 @@ INSERT INTO c VALUES (1, 1);
 --reap
 
 --connection node_2
-SELECT * FROM p;
-SELECT * FROM c;
+SELECT * FROM pc;
+SELECT * FROM cc;
 
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE cc;
+DROP TABLE pc;
 
 
 #
@@ -155,8 +155,8 @@ DROP TABLE p;
 # but this key value is changed so that insert on node 2 will cause FK
 # violation
 #
-# The p table will originally have rows (1, 0)
-# The c table will originally be empty 
+# The pd table will originally have rows (1, 0)
+# The cd table will originally be empty
 #
 # in node_1, parent row is updated to value (1,1)
 # A row (1, 0) pointing to the old version of parent row (1, 0) is inserted
@@ -164,20 +164,20 @@ DROP TABLE p;
 #
 # Expected Outcome:
 # ================
-# This is a true conflict and one transaciton must abort. In this case it is node_1
-# transaction, which was scheduled later.
+# This is a true conflict and one transaciton must abort. In this case it is
+# node_1 transaction, which was scheduled later.
 #    Parent table should have row (1,0)
 #    child table should have row (1,0)
 #
 
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER,
-                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f2))  ;
+CREATE TABLE pd (f1 INTEGER PRIMARY KEY, f2 INTEGER UNIQUE KEY) ENGINE=INNODB;
+CREATE TABLE cd (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pd (f2))  ;
 
-INSERT INTO p VALUES (1, 0);
+INSERT INTO pd VALUES (1, 0);
 
---let $mw_369_parent_query = UPDATE p SET f2 = 1 WHERE f1 = 1
---let $mw_369_child_query = INSERT INTO c VALUES (1, 0);
+--let $mw_369_parent_query = UPDATE pd SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = INSERT INTO cd VALUES (1, 0);
 --source MW-369.inc
 
 # Commit fails
@@ -186,11 +186,11 @@ INSERT INTO p VALUES (1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM p;
-SELECT * FROM c;
+SELECT * FROM pd;
+SELECT * FROM cd;
 
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE cd;
+DROP TABLE pd;
 
 #
 # Test E Outline:
@@ -202,8 +202,8 @@ DROP TABLE p;
 # cascade a delete on child row as well. This will cause true conflict with 
 # connection node_2, which tries to update unrelated column on child table.
 #
-# The p table will originally have rows (1, 0), (2,0)
-# The c table will originally have row (1,1,0)
+# The pe table will originally have rows (1, 0), (2,0)
+# The ce table will originally have row (1,1,0)
 #
 # in node_1, parent row (1,0) is deleted and cascaded delete will happen on
 # child table row (1,1,0).
@@ -218,17 +218,17 @@ DROP TABLE p;
 #
 
 
-CREATE TABLE p (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
-CREATE TABLE c (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
-                CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES p (f1)
-                ON DELETE CASCADE)  ;
+CREATE TABLE pe (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE ce (f1 INTEGER PRIMARY KEY, p_id INTEGER, f2 INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pe (f1)
+                 ON DELETE CASCADE)  ;
 
-INSERT INTO p VALUES (1, 0);
-INSERT INTO p VALUES (2, 0);
-INSERT INTO c VALUES (1, 1, 0);
+INSERT INTO pe VALUES (1, 0);
+INSERT INTO pe VALUES (2, 0);
+INSERT INTO ce VALUES (1, 1, 0);
 
---let $mw_369_parent_query = DELETE FROM p WHERE f1 = 1
---let $mw_369_child_query = UPDATE c SET f2 = 1 WHERE f1 = 1
+--let $mw_369_parent_query = DELETE FROM pe WHERE f1 = 1
+--let $mw_369_child_query = UPDATE ce SET f2 = 1 WHERE f1 = 1
 --source MW-369.inc
 
 # Commit fails
@@ -237,9 +237,104 @@ INSERT INTO c VALUES (1, 1, 0);
 --reap
 
 --connection node_2
-SELECT * FROM p;
-SELECT * FROM c;
+SELECT * FROM pe;
+SELECT * FROM ce;
 
-DROP TABLE c;
-DROP TABLE p;
+DROP TABLE ce;
+DROP TABLE pe;
+
+#
+# Test F Outline:
+# ===============
+#
+# Test two concurrent INSERTs on the child table.
+#
+# The pf table will originally have row (1)
+# The cf table will originally be empty
+#
+# A new row (10, 1) pointing to parent row (1) is inserted from
+# connection node_2. A transaction which tries to INSERT another child
+# row (20, 1), pointing to the same parent, is run from connection node_1.
+#
+# Expected Outcome:
+# =================
+# Both INSERTs should succeed since they don't modify the common parent
+# key.
+#
+# At the end of the test:
+#    parent table should have row (1)
+#    child table should have rows (10, 1), (20, 1)
+
+--connection node_1
+
+CREATE TABLE pf (f1 INTEGER PRIMARY KEY) ENGINE=INNODB;
+CREATE TABLE cf (
+  f1 INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pf (f1)
+);
+
+INSERT INTO pf VALUES (1);
+
+# This is run on node1:
+--let $mw_369_parent_query = INSERT INTO cf (f1, p_id) VALUES (10, 1)
+# This is run on node2:
+--let $mw_369_child_query = INSERT INTO cf (f1, p_id) VALUES (20, 1)
+--source MW-369.inc
+
+--connection node_1
+--reap
+
+--connection node_2
+SELECT * FROM pf;
+SELECT * FROM cf;
+
+DROP TABLE cf;
+DROP TABLE pf;
+
+#
+# Test G Outline:
+# ===============
+#
+# This test is similar to test B where a existing
+# child table row is updated concurrently from another node
+# with a transaction which updates the parent table, except
+# that here the child table row is inserted, not updated.
+#
+# The pg table will originally have rows (1, 0), (2, 0).
+# The cg table will originally be empty
+#
+# Expected outcome:
+# ================
+#
+# Both UPDATE and INSERT should succeed since they are done to separate tables
+# and UPDATE to parent row does not touch the foreign key referenced by the
+# child row INSERT. The parent table shall contain rows (1, 1), (2, 0).
+# The child table shall contain row (1, 1, 0) which points to parent table
+# row (1, 0).
+#
+
+--connection node_1
+CREATE TABLE pg (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE cg (f1 INTEGER PRIMARY KEY, p_id INTEGER,
+                 f2 INTEGER,
+                 CONSTRAINT fk_1 FOREIGN KEY (p_id) REFERENCES pg (f1))  ;
+
+INSERT INTO pg VALUES (1, 0);
+INSERT INTO pg VALUES (2, 0);
+
+--let mw_369_parent_query = UPDATE pg SET f2 = 1 WHERE f1 = 1
+--let $mw_369_child_query = INSERT INTO cg VALUES (1, 1, 0)
+--source MW-369.inc
+
+# Commit succeeds
+--connection node_1
+--reap
+
+--connection node_2
+SELECT * FROM pg;
+SELECT * FROM cg;
+
+DROP TABLE cg;
+DROP TABLE pg;
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -295,9 +295,9 @@ map_key_type(enum Wsrep_key_type type)
 {
   switch (type)
   {
-  case wsrep_key_shared: return wsrep::key::shared;
-  case wsrep_key_semi_shared: return wsrep::key::semi_shared;
-  case wsrep_key_semi_exclusive: return wsrep::key::semi_exclusive;
+  case wsrep_key_shared:    return wsrep::key::shared;
+  case wsrep_key_reference: return wsrep::key::reference;
+  case wsrep_key_update:    return wsrep::key::update;
   case wsrep_key_exclusive: return wsrep::key::exclusive;
   }
   return wsrep::key::exclusive;

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -291,14 +291,14 @@ extern "C" my_bool wsrep_thd_is_aborting(const void* thd_ptr)
 }
 
 static inline enum wsrep::key::type
-map_key_type(enum Wsrep_key_type type)
+map_key_type(enum Wsrep_service_key_type type)
 {
   switch (type)
   {
-  case wsrep_key_shared:    return wsrep::key::shared;
-  case wsrep_key_reference: return wsrep::key::reference;
-  case wsrep_key_update:    return wsrep::key::update;
-  case wsrep_key_exclusive: return wsrep::key::exclusive;
+  case WSREP_SERVICE_KEY_SHARED:    return wsrep::key::shared;
+  case WSREP_SERVICE_KEY_REFERENCE: return wsrep::key::reference;
+  case WSREP_SERVICE_KEY_UPDATE:    return wsrep::key::update;
+  case WSREP_SERVICE_KEY_EXCLUSIVE: return wsrep::key::exclusive;
   }
   return wsrep::key::exclusive;
 }
@@ -306,7 +306,7 @@ map_key_type(enum Wsrep_key_type type)
 extern "C" int wsrep_thd_append_key(void* thd_ptr,
                                     const struct wsrep_key* key,
                                     int n_keys,
-                                    enum Wsrep_key_type key_type)
+                                    enum Wsrep_service_key_type key_type)
 {
   THD* thd= (THD*)thd_ptr;
   Wsrep_client_state& client_state(thd->wsrep_cs());

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -4594,7 +4594,7 @@ bool select_create::send_eof()
                                        table_list,
                                        &key_arr);
       int rcode= wsrep_thd_append_key(thd, key_arr.keys, key_arr.keys_len,
-                                      wsrep_key_exclusive);
+                                      WSREP_SERVICE_KEY_EXCLUSIVE);
       wsrep_keys_free(&key_arr);
       if (rcode)
       {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10179,9 +10179,9 @@ extern dberr_t
 wsrep_append_foreign_key(
 	trx_t*		trx,		/*!< in: trx */
 	dict_foreign_t*	foreign,	/*!< in: foreign key constraint */
-	const rec_t*	rec,		/*!< in: clustered index record */
-	dict_index_t*	index,		/*!< in: clustered index */
-	ibool		referenced,	/*!< in: is check for referenced table */
+	const rec_t*	rec,		/*!<in: clustered index record */
+	dict_index_t*	index,		/*!<in: clustered index */
+	ibool		referenced,	/*!<in: is check for referenced table */
 	Wsrep_service_key_type	key_type)	/*!< in: access type of this key
 					(shared, exclusive, reference...) */
 {
@@ -10319,7 +10319,7 @@ wsrep_append_foreign_key(
 	}
 
 	wsrep_buf_t wkey_part[3];
-	wsrep_key_t wkey = {wkey_part, 3};
+        wsrep_key_t wkey = {wkey_part, 3};
 
 	if (!wsrep_prepare_key_for_innodb(
 		thd,
@@ -10411,17 +10411,17 @@ referenced_by_foreign_key2(
 	const dict_foreign_set* fks = &table->referenced_set;
 
 	for (dict_foreign_set::const_iterator it = fks->begin();
-	     it != fks->end();
-	     ++it) {
-		dict_foreign_t* foreign = *it;
+             it != fks->end();
+             ++it) {
+                dict_foreign_t* foreign = *it;
 
-		if (foreign->referenced_index != index) {
-			continue;
-		}
-		ut_ad(table == foreign->referenced_table);
-		return true;
-	}
-	return false;
+                if (foreign->referenced_index != index) {
+                        continue;
+                }
+                ut_ad(table == foreign->referenced_table);
+                return true;
+        }
+        return false;
 }
 
 int
@@ -10462,9 +10462,9 @@ ha_innobase::wsrep_append_keys(
 
 	if (wsrep_protocol_version == 0) {
 		uint	len;
-		char	keyval[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
-		char	*key = &keyval[0];
-		ibool	is_null;
+		char 	keyval[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
+		char 	*key 		= &keyval[0];
+		ibool    is_null;
 
 		len = wsrep_store_key_val_for_row(
 			thd, table, 0, key, WSREP_MAX_SUPPORTED_KEY_LENGTH,
@@ -10498,8 +10498,8 @@ ha_innobase::wsrep_append_keys(
 		for (i=0; i<table->s->keys; ++i) {
 			KEY*  key_info	= table->key_info + i;
 
-			dict_index_t* idx = innobase_get_index(i);
-			dict_table_t* tab = (idx) ? idx->table : NULL;
+			dict_index_t* idx  = innobase_get_index(i);
+			dict_table_t* tab  = (idx) ? idx->table : NULL;
 
 			/* keyval[] shall contain an ordinal number at byte 0
 			   and the actual key data shall be written at byte 1.
@@ -10597,8 +10597,8 @@ ha_innobase::wsrep_append_keys(
 			wsrep_calc_row_hash(
 				digest, record1, table, m_prebuilt);
 			if ((rcode = wsrep_append_key(thd, trx, table_share,
-						      (const char*) digest, 16,
-						      key_type))) {
+						      (const char*) digest,
+						      16, key_type))) {
 				DBUG_RETURN(rcode);
 			}
 		}

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8903,10 +8903,11 @@ func_exit:
 
 		DBUG_PRINT("wsrep", ("update row key"));
 
-		Wsrep_service_key_type key_type = wsrep_protocol_version >= 4
-			? WSREP_SERVICE_KEY_UPDATE
-			: WSREP_SERVICE_KEY_EXCLUSIVE;
-		if (wsrep_append_keys(m_user_thd, key_type, old_row, new_row)){
+		if (wsrep_append_keys(m_user_thd,
+				      wsrep_protocol_version >= 4
+				      ? WSREP_SERVICE_KEY_UPDATE
+				      : WSREP_SERVICE_KEY_EXCLUSIVE,
+				      old_row, new_row)){
 			WSREP_DEBUG("WSREP: UPDATE_ROW_KEY FAILED");
 			DBUG_PRINT("wsrep", ("row key failed"));
 			err = HA_ERR_INTERNAL_ERROR;

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -450,7 +450,7 @@ protected:
 #ifdef WITH_WSREP
 	int wsrep_append_keys(
 		THD *thd,
-		wsrep_key_type key_type,
+		Wsrep_key_type key_type,
 		const uchar* record0,
 		const uchar* record1);
 #endif

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -450,7 +450,7 @@ protected:
 #ifdef WITH_WSREP
 	int wsrep_append_keys(
 		THD *thd,
-		Wsrep_key_type key_type,
+		Wsrep_service_key_type key_type,
 		const uchar* record0,
 		const uchar* record1);
 #endif

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1806,20 +1806,16 @@ row_ins_check_foreign_constraint(
 				if (check_ref) {
 					err = DB_SUCCESS;
 #ifdef WITH_WSREP
-					Wsrep_service_key_type key_type;
-					if (upd_node != NULL &&
-					    wsrep_protocol_version < 4) {
-						key_type = WSREP_SERVICE_KEY_SHARED;
-					} else {
-						key_type = WSREP_SERVICE_KEY_REFERENCE;
-					}
 					err = wsrep_append_foreign_key(
 						thr_get_trx(thr),
 						foreign,
 						rec,
 						check_index,
 						check_ref,
-						key_type);
+						upd_node != NULL &&
+						wsrep_protocol_version < 4
+						? WSREP_SERVICE_KEY_SHARED
+						: WSREP_SERVICE_KEY_REFERENCE);
 #endif /* WITH_WSREP */
 					goto end_scan;
 				} else if (foreign->type != 0) {

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1040,11 +1040,11 @@ func_exit:
 
 #ifdef WITH_WSREP
 dberr_t wsrep_append_foreign_key(trx_t *trx,
-			       dict_foreign_t*	foreign,
-			       const rec_t*	clust_rec,
-			       dict_index_t*	clust_index,
-			       ibool		referenced,
-			       wsrep_key_type	key_type);
+				 dict_foreign_t*	foreign,
+				 const rec_t*		clust_rec,
+				 dict_index_t*		clust_index,
+				 ibool			referenced,
+				 Wsrep_key_type		key_type);
 #endif /* WITH_WSREP */
 
 /*********************************************************************//**
@@ -1431,7 +1431,7 @@ row_ins_foreign_check_on_constraint(
 
 #ifdef WITH_WSREP
 	err = wsrep_append_foreign_key(trx, foreign, clust_rec, clust_index,
-				       FALSE,  WSREP_KEY_EXCLUSIVE);
+				       FALSE, wsrep_key_exclusive);
 	if (err != DB_SUCCESS) {
 		fprintf(stderr,
 			"WSREP: foreign key append failed: %d\n", err);
@@ -1806,13 +1806,20 @@ row_ins_check_foreign_constraint(
 				if (check_ref) {
 					err = DB_SUCCESS;
 #ifdef WITH_WSREP
+					Wsrep_key_type key_type;
+					if (upd_node != NULL &&
+					    wsrep_protocol_version < 4) {
+						key_type = wsrep_key_shared;
+					} else {
+						key_type = wsrep_key_reference;
+					}
 					err = wsrep_append_foreign_key(
 						thr_get_trx(thr),
 						foreign,
 						rec,
 						check_index,
 						check_ref,
-						upd_node != NULL ? WSREP_KEY_SHARED : WSREP_KEY_SEMI);
+						key_type);
 #endif /* WITH_WSREP */
 					goto end_scan;
 				} else if (foreign->type != 0) {

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1044,7 +1044,7 @@ dberr_t wsrep_append_foreign_key(trx_t *trx,
 				 const rec_t*		clust_rec,
 				 dict_index_t*		clust_index,
 				 ibool			referenced,
-				 Wsrep_key_type		key_type);
+				 Wsrep_service_key_type		key_type);
 #endif /* WITH_WSREP */
 
 /*********************************************************************//**
@@ -1431,7 +1431,7 @@ row_ins_foreign_check_on_constraint(
 
 #ifdef WITH_WSREP
 	err = wsrep_append_foreign_key(trx, foreign, clust_rec, clust_index,
-				       FALSE, wsrep_key_exclusive);
+				       FALSE, WSREP_SERVICE_KEY_EXCLUSIVE);
 	if (err != DB_SUCCESS) {
 		fprintf(stderr,
 			"WSREP: foreign key append failed: %d\n", err);
@@ -1806,12 +1806,12 @@ row_ins_check_foreign_constraint(
 				if (check_ref) {
 					err = DB_SUCCESS;
 #ifdef WITH_WSREP
-					Wsrep_key_type key_type;
+					Wsrep_service_key_type key_type;
 					if (upd_node != NULL &&
 					    wsrep_protocol_version < 4) {
-						key_type = wsrep_key_shared;
+						key_type = WSREP_SERVICE_KEY_SHARED;
 					} else {
-						key_type = wsrep_key_reference;
+						key_type = WSREP_SERVICE_KEY_REFERENCE;
 					}
 					err = wsrep_append_foreign_key(
 						thr_get_trx(thr),

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1040,11 +1040,11 @@ func_exit:
 
 #ifdef WITH_WSREP
 dberr_t wsrep_append_foreign_key(trx_t *trx,
-				 dict_foreign_t*	foreign,
-				 const rec_t*		clust_rec,
-				 dict_index_t*		clust_index,
-				 ibool			referenced,
-				 Wsrep_service_key_type		key_type);
+			       dict_foreign_t*	foreign,
+			       const rec_t*	clust_rec,
+			       dict_index_t*	clust_index,
+			       ibool		referenced,
+			       Wsrep_service_key_type	key_type);
 #endif /* WITH_WSREP */
 
 /*********************************************************************//**


### PR DESCRIPTION
for the UPDATE key type. In particular mark keys for the
UPDATE operation as UPDATE instead of EXCLUSIVE depending
on the cluster-wide supported application protocol version
to reduce the possibility of multi-master conflicts when
updating parent tables.