### PR TITLE
Fixes for rsync SST

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1286,7 +1286,9 @@ static int sst_donate_other (const char*        method,
   }
 
   const char* binlog_opt= "";
+  const char* binlog_index_opt= "";
   char* binlog_opt_val= NULL;
+  char* binlog_index_opt_val= NULL;
 
   int ret;
   if ((ret= generate_binlog_opt_val(&binlog_opt_val)))
@@ -1294,7 +1296,15 @@ static int sst_donate_other (const char*        method,
     WSREP_ERROR("sst_donate_other(): generate_binlog_opt_val() failed: %d",ret);
     return ret;
   }
+
+  if ((ret= generate_binlog_index_opt_val(&binlog_index_opt_val)))
+  {
+    WSREP_ERROR("sst_prepare_other(): generate_binlog_index_opt_val() failed %d",
+                ret);
+  }
+
   if (strlen(binlog_opt_val)) binlog_opt= WSREP_SST_OPT_BINLOG;
+  if (strlen(binlog_index_opt_val)) binlog_index_opt= WSREP_SST_OPT_BINLOG_INDEX;
 
   std::ostringstream uuid_oss;
   uuid_oss << gtid.id();
@@ -1306,12 +1316,14 @@ static int sst_donate_other (const char*        method,
                  WSREP_SST_OPT_DATA " '%s' "
                  " %s "
                  " %s '%s' "
+                 " %s '%s' "
                  WSREP_SST_OPT_GTID " '%s:%lld' "
                  WSREP_SST_OPT_GTID_DOMAIN_ID " '%d'"
                  "%s",
                  method, addr, mysqld_unix_port, mysql_real_data_home,
                  wsrep_defaults_file,
                  binlog_opt, binlog_opt_val,
+                 binlog_index_opt, binlog_index_opt_val,
                  uuid_oss.str().c_str(), gtid.seqno().get(), wsrep_gtid_domain_id,
                  bypass ? " " WSREP_SST_OPT_BYPASS : "");
   my_free(binlog_opt_val);
@@ -1389,4 +1401,3 @@ int wsrep_sst_donate(const std::string& msg,
 
   return (ret >= 0 ? 0 : 1);
 }
-  


### PR DESCRIPTION
* Donor node will now provide log-bin-index argument to wsrep_sst_rsync script
* If log-bin-index name is ending in '.index'  don't append another '.index'
* Write correct path and log-bin file names into joiner  log-bin-index file