### PR TITLE
Fixup for commit "Fix for sql_sequence.create innodb test"

### DIFF
--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -3249,9 +3249,8 @@ row_ins_clust_index_entry(
 #ifdef WITH_WSREP
 	const bool skip_locking
 		= wsrep_thd_skip_locking(thr_get_trx(thr)->mysql_thd);
-	ulint	flags = skip_locking |
-			index->table->no_rollback() ? BTR_NO_ROLLBACK
-		: index->table->is_temporary()
+	ulint	flags = index->table->no_rollback() ? BTR_NO_ROLLBACK
+		: (index->table->is_temporary() || skip_locking)
 		? BTR_NO_LOCKING_FLAG : 0;
 #ifdef UNIV_DEBUG
 	if (skip_locking && sr_table_name_full_str != index->table->name.m_name) {


### PR DESCRIPTION
This patch fixes regressions commit:
     d3cd7aa76f078063029b8e7a4adb4fd65099bfa5

That commit fixed sql_sequence.create test, but introduced many
regressions in SR tests. The fix changes flags set in function
row_ins_clust_index_entry() so that:
a) wsrep skip_locking logic is restored (i.e. if skip_locking is set
   we want flag BTR_NO_LOCKING_FLAG);
b) the original logic of innodb is preserved (i.e. condition for
   BTR_NO_ROLLBACK should be evaluated before condition for
   BTR_NO_LOCKING_FLAG)