### PR TITLE
Updated wsrep-lib submodule, recorded galera_var_dirty_reads2

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_var_dirty_reads2.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_var_dirty_reads2.result
@@ -1,6 +1,11 @@
+connection node_2;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER);
 INSERT INTO t1 VALUES (1);
+connection node_2;
 SET GLOBAL wsrep_provider_options='gmcast.isolate=1';
+connection node_1;
+connection node_2;
 SET SESSION wsrep_sync_wait = 0;
 SET SESSION wsrep_dirty_reads = 1;
 SELECT f1 FROM t1;
@@ -45,4 +50,6 @@ SELECT COUNT(*) > 0 FROM INFORMATION_SCHEMA.PROCESSLIST;
 COUNT(*) > 0
 1
 SET GLOBAL wsrep_provider_options='gmcast.isolate=0';
+connection node_1;
+connection node_2;
 DROP TABLE t1;

--- a/mysql-test/suite/galera_3nodes/t/galera_var_dirty_reads2.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_var_dirty_reads2.test
@@ -106,7 +106,8 @@ SET GLOBAL wsrep_provider_options='gmcast.isolate=0';
 --source include/wait_condition.inc
 
 --connection node_2
---let $wait_condition = SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 --source include/wait_condition.inc
+--source include/galera_wait_ready.inc
 
 DROP TABLE t1;


### PR DESCRIPTION
Wsrep-lib submodule was updated to position which fixes
an assertion after desync/pause, resume/resync operations
in non-primary view. Recorded galera_var_dirty_reads2 which
is now passing.