### PR TITLE
WSREP doesn't handle wildcard bind address

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -501,7 +501,8 @@ static std::string wsrep_server_incoming_address()
     bool is_ipv6= false;
     unsigned int my_bind_ip= INADDR_ANY; // default if not set
 
-    if (my_bind_addr_str && strlen(my_bind_addr_str))
+    if (my_bind_addr_str && strlen(my_bind_addr_str) && 
+        strcmp(my_bind_addr_str, "*") != 0)
     {
       my_bind_ip= wsrep_check_ip(my_bind_addr_str, &is_ipv6);
     }
@@ -612,7 +613,6 @@ int wsrep_init_server()
     incoming_address= wsrep_server_incoming_address();
     working_dir= wsrep_server_working_dir();
     initial_position= wsrep_server_initial_position();
-
 
     Wsrep_server_state::init_once(server_name,
                                   incoming_address,

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -490,7 +490,9 @@ size_t wsrep_guess_ip (char* buf, size_t buf_len)
   size_t ret= 0;
 
   // Attempt 1: Try to get the IP from bind-address.
-  if (my_bind_addr_str && my_bind_addr_str[0] != '\0')
+  // Skip if empty or bind-address=*
+  if (my_bind_addr_str && my_bind_addr_str[0] != '\0' &&
+      strcmp(my_bind_addr_str, "*") != 0)
   {
     bool unused;
     unsigned int const ip_type= wsrep_check_ip(my_bind_addr_str, &unused);


### PR DESCRIPTION
When bootstrapping wsrep, we need to set IP address to bind on. If bind-address=* this will fail. Skipping guess from bind-address if it is set to *.