### PR TITLE
Revert changes to wait_wsrep_ready.inc

### DIFF
--- a/mysql-test/include/wait_wsrep_ready.inc
+++ b/mysql-test/include/wait_wsrep_ready.inc
@@ -6,28 +6,12 @@
 --disable_query_log
 --disable_result_log
 
-#
-# Firstly, make sure that wsrep plugin is available
-#
 if (`SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'wsrep' AND PLUGIN_STATUS='ACTIVE'`)
 {
-#
-# if node is not ready, SELECT @@GLOBAL.WSREP_ON below does not
-# succeed. However, we can force it to succeed by running the SELECT
-# with dirty reads configuration. So we prepare for that
-#
-  --let $my_dirty_reads= `select @@wsrep_dirty_reads`
-  SET wsrep_dirty_reads = ON;
-
   if (`SELECT @@GLOBAL.WSREP_ON`)
   {
     --source include/galera_wait_ready.inc
-    --disable_query_log
-    --disable_result_log
   }
-
-# ..and returning original dirty read selection here
-  --eval SET wsrep_dirty_reads = $my_dirty_reads;
 }
 
 --enable_query_log


### PR DESCRIPTION
This reverts unnecessary changes to wait_wsrep_ready.inc:

* Setting wsrep_dirty_reads is unnecessary because client should be
  allowed to read global variables and from information schema tables
  even if the server is not ready yet.

* Removed spurious disable_query_logs and disable_result_log