### PR TITLE
Fixes for MTR test galera_sr.galera_sr_kill_query

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_kill_query.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_kill_query.result
@@ -13,6 +13,12 @@ Killing query ...
 connection node_1;
 ERROR 70100: Query execution was interrupted
 connection node_2;
+SELECT COUNT(*) = 0 FROM t1;
+COUNT(*) = 0
+1
+SELECT COUNT(*) = 0 FROM wsrep_schema.SR;
+COUNT(*) = 0
+1
 INSERT INTO t1 SELECT 1 FROM ten AS t1, ten AS t2, ten AS t3;
 SELECT COUNT(*) = 1000 FROM t1;
 COUNT(*) = 1000

--- a/mysql-test/suite/galera_sr/t/galera_sr_kill_query.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_kill_query.test
@@ -1,6 +1,4 @@
 --source include/galera_cluster.inc
---source include/have_innodb.inc
---source include/big_test.inc
 
 #
 # Test KILL QUERY on a statement that has already replicated some data via SR
@@ -35,11 +33,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 # Confirm that the kill caused the updates made so far to be removed
 --connection node_2
---let $wait_condition = SELECT COUNT(*) = 0 FROM t1;
---source include/wait_condition.inc
-
---let $wait_condition = SELECT COUNT(*) = 0 FROM wsrep_schema.SR;
---source include/wait_condition.inc
+SELECT COUNT(*) = 0 FROM t1;
+SELECT COUNT(*) = 0 FROM wsrep_schema.SR;
 
 # Confirm that the transaction can be reissued in its entirety on the slave without a conflict
 


### PR DESCRIPTION
* Removed have_innodb.inc: test already sources galera_cluster.inc

* Removed big_test.inc: test is quite quick

* Changed wait conditions:
  ```
  --let $wait_condition = SELECT COUNT(*) = 0 FROM t1;
  --source include/wait_condition.inc
  ```
  to simple query:
  `SELECT COUNT(*) = 0 FROM t1;`

  wsrep_sync_wait is enabled, no need for wait_condition

* Updated wsrep-lib to include commit "Check if client was interrupted
  before fragment replication"