### PR TITLE
Disable streaming in THD::init()

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -69,7 +69,6 @@
 #include "sql_connect.h"
 #ifdef WITH_WSREP
 #include "mysql/service_wsrep.h"
-#include "wsrep_binlog.h" /* wsrep_fragment_unit() */
 #include "wsrep_thd.h"
 #include "wsrep_trans_observer.h"
 #endif /* WITH_WSREP */
@@ -1272,11 +1271,6 @@ void THD::init(bool skip_lock)
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
-  if (!wsrep_applier && variables.wsrep_trx_fragment_size)
-  {
-    wsrep_cs().enable_streaming(wsrep_fragment_unit(variables.wsrep_trx_fragment_unit),
-                                variables.wsrep_trx_fragment_size);
-  }
 #endif /* WITH_WSREP */
 
   if (variables.sql_log_bin)

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -23,9 +23,6 @@
 
 #include "transaction.h"
 
-const char *wsrep_fragment_units[]= { "bytes", "rows", "statements", NullS };
-const char *wsrep_SR_store_types[]= { "none", "table", NullS };
-
 extern handlerton *binlog_hton;
 /*
   Write the contents of a cache to a memory buffer.

--- a/sql/wsrep_binlog.h
+++ b/sql/wsrep_binlog.h
@@ -17,33 +17,6 @@
 #define WSREP_BINLOG_H
 
 #include "my_global.h"
-
-#define WSREP_FRAG_BYTES      0
-#define WSREP_FRAG_ROWS       1
-#define WSREP_FRAG_STATEMENTS 2
-#include "wsrep/streaming_context.hpp"
-static inline enum wsrep::streaming_context::fragment_unit
-wsrep_fragment_unit(ulong unit)
-{
-  switch (unit)
-  {
-  case WSREP_FRAG_BYTES: return wsrep::streaming_context::bytes;
-  case WSREP_FRAG_ROWS: return wsrep::streaming_context::row;
-  case WSREP_FRAG_STATEMENTS: return wsrep::streaming_context::statement;
-  default:
-    DBUG_ASSERT(0);
-    return wsrep::streaming_context::bytes;
-  }
-}
-
-#define WSREP_SR_STORE_NONE      0
-#define WSREP_SR_STORE_TABLE     1
-
-extern ulong wsrep_SR_store_type;
-extern const char *wsrep_fragment_units[];
-extern const char *wsrep_SR_store_types[];
-
-class wsrep_SR_trx;
 #include "sql_class.h" // THD, IO_CACHE
 
 #define HEAP_PAGE_SIZE 65536 /* 64K */

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -61,6 +61,10 @@ rpl_sidno wsrep_sidno= -1;
 #endif /* GTID_SUPPORT */
 my_bool wsrep_preordered_opt= FALSE;
 
+/* Streaming Replication */
+const char *wsrep_fragment_units[]= { "bytes", "rows", "statements", NullS };
+const char *wsrep_SR_store_types[]= { "none", "table", NullS };
+
 /*
  * Begin configuration options
  */
@@ -3019,6 +3023,18 @@ error:
     return NULL;
 }
 
+enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit)
+{
+  switch (unit)
+  {
+  case WSREP_FRAG_BYTES: return wsrep::streaming_context::bytes;
+  case WSREP_FRAG_ROWS: return wsrep::streaming_context::row;
+  case WSREP_FRAG_STATEMENTS: return wsrep::streaming_context::statement;
+  default:
+    DBUG_ASSERT(0);
+    return wsrep::streaming_context::bytes;
+  }
+}
 
 /***** callbacks for wsrep service ************/
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -34,6 +34,7 @@ typedef struct st_mysql_show_var SHOW_VAR;
 #include "sql_table.h"
 
 #include "wsrep/provider.hpp"
+#include "wsrep/streaming_context.hpp"
 #include "wsrep_api.h"
 #include <vector>
 #include "wsrep_server_state.h"
@@ -126,6 +127,17 @@ enum enum_wsrep_ignore_apply_error {
     WSREP_IGNORE_ERRORS_ON_DDL= 0x4,
     WSREP_IGNORE_ERRORS_MAX= 0x7
 };
+
+// Streaming Replication
+#define WSREP_FRAG_BYTES      0
+#define WSREP_FRAG_ROWS       1
+#define WSREP_FRAG_STATEMENTS 2
+
+#define WSREP_SR_STORE_NONE   0
+#define WSREP_SR_STORE_TABLE  1
+
+extern const char *wsrep_fragment_units[];
+extern const char *wsrep_SR_store_types[];
 
 // MySQL status variables
 extern my_bool     wsrep_connected;
@@ -556,6 +568,12 @@ void wsrep_init_globals();
  * Deinit and release WSREP resources.
  */
 void wsrep_deinit_server();
+
+/**
+ * Convert streaming fragment unit (WSREP_FRAG_BYTES, WSREP_FRAG_ROWS...)
+ * to corresponding wsrep-lib fragment_unit
+ */
+enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit);
 
 #else /* !WITH_WSREP */
 

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -310,6 +310,12 @@ static inline void wsrep_open(THD* thd)
   {
     thd->wsrep_cs().open(wsrep::client_id(thd->thread_id));
     thd->wsrep_cs().debug_log_level(wsrep_debug);
+    if (!thd->wsrep_applier && thd->variables.wsrep_trx_fragment_size)
+    {
+      thd->wsrep_cs().enable_streaming(
+        wsrep_fragment_unit(thd->variables.wsrep_trx_fragment_unit),
+        thd->variables.wsrep_trx_fragment_size);
+    }
   }
   DBUG_VOID_RETURN;
 }

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -22,7 +22,6 @@
 #include "wsrep_priv.h"
 #include "wsrep_thd.h"
 #include "wsrep_xid.h"
-#include "wsrep_binlog.h" /* wsrep_fragment_unit() */
 #include <my_dir.h>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
Adds missing call to disable streaming replication in THD::init().
This caused some tests to fail if streaming was first enable, and then
disabled on a subsequent test. The subsequent test would still use
streaming replication, while regular replication was expected.
For example, galera_sr.GCF-597 failed if preceeded by galera_sr.GCF-585.