### PR TITLE
Fixed wsrep_sst_mysqldump script when executing RESET MASTER

### DIFF
--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -139,8 +139,8 @@ then
   # turned off for the session so that gtid state does not get altered while
   # the dump gets replayed on joiner.
   if [[ "$LOG_BIN" == 'ON' ]]; then
-    RESET_MASTER="RESET MASTER;"
-    SET_GTID_BINLOG_STATE="SET @@global.gtid_binlog_state='$GTID_BINLOG_STATE';"
+    RESET_MASTER="SET GLOBAL wsrep_on=OFF; RESET MASTER;SET GLOBAL wsrep_on=ON;"
+    SET_GTID_BINLOG_STATE="SET GLOBAL wsrep_on=OFF; SET @@global.gtid_binlog_state='$GTID_BINLOG_STATE'; SET GLOBAL wsrep_on=ON;"
     SQL_LOG_BIN_OFF="SET @@session.sql_log_bin=OFF;"
   fi
 fi


### PR DESCRIPTION
If LOG_BIN is enabled on joiner side, we will execute RESET MASTER. This command will fail if wsrep_on=ON. Fixed by disable wsrep_on and restoring variable at the end.