### PR TITLE
Add method Wsrep_client_service::query()

### DIFF
--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -54,6 +54,11 @@ Wsrep_client_service::Wsrep_client_service(THD* thd,
   , m_client_state(client_state)
 { }
 
+std::string Wsrep_client_service::query() const
+{
+  return WSREP_QUERY(m_thd);
+}
+
 void Wsrep_client_service::store_globals()
 {
   DBUG_ENTER("Wsrep_client_service::store_globals");

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -36,6 +36,7 @@ class Wsrep_client_service : public wsrep::client_service
 public:
   Wsrep_client_service(THD*, Wsrep_client_state&);
 
+  std::string query() const;
   bool interrupted() const;
   void reset_globals();
   void store_globals();


### PR DESCRIPTION
The method return the current query, and is simply used by wsrep-lib
for debug logging.