### PR TITLE
Fixes for rsync/mariabackup SST

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -51,7 +51,6 @@ galera.galera_var_reject_queries : assertion in inline_mysql_socket_send
 query_cache : MDEV-18137: Galera test failure on query_cache
 galera.galera_autoinc_sst_mariabackup : MDEV-18177 Galera test failure on galera_autoinc_sst_mariabackup
 galera.galera_ist_mariabackup : Leaves port open
-galera.galera_sst_rsync2 : MDEV-18178 Galera test failure on galera_sst_rsync2
 galera.galera_kill_largechanges : MDEV-18179 Galera test failure on galera.galera_kill_largechanges
 galera.galera_concurrent_ctas : MDEV-18180 Galera test failure on galera.galera_concurrent_ctas
 galera.galera_var_retry_autocommit: MDEV-18181 Galera test failure on galera.galera_var_retry_autocommit

--- a/mysql-test/suite/galera/r/galera_gcache_recover_manytrx.result
+++ b/mysql-test/suite/galera/r/galera_gcache_recover_manytrx.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 SET SESSION wsrep_sync_wait = 0;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 LONGBLOB) ENGINE=InnoDB;
 CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;

--- a/mysql-test/suite/galera/r/galera_sst_rsync2.result
+++ b/mysql-test/suite/galera/r/galera_sst_rsync2.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 connection node_2;
 Performing State Transfer on a server that has been shut down cleanly and restarted

--- a/mysql-test/suite/galera_3nodes/r/galera_evs_suspect_timeout.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_evs_suspect_timeout.result
@@ -25,5 +25,4 @@ COUNT(*) = 1
 DROP TABLE t1;
 connection node_3;
 Resuming node ...
-connection node_3;
 CALL mtr.add_suppression("WSREP: gcs_caused() returned -1 \\(Operation not permitted\\)");

--- a/mysql-test/suite/galera_3nodes/t/galera_evs_suspect_timeout.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_evs_suspect_timeout.test
@@ -56,8 +56,8 @@ DROP TABLE t1;
 
 # Reconnect node #3 so that MTR's end-of-test checks can run
 
---source include/galera_resume.inc
 --connection node_3
+--source include/galera_resume.inc
 --source include/wait_until_connected_again.inc
 
 --disable_query_log

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -753,8 +753,8 @@ else
 
 if [[ "$sstlogarchive" -eq 1 ]]
 then
-    ARCHIVETIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-    newfile=""    
+    ARCHIVETIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S.%N")
+    newfile=""
 
     if [[ ! -z "$sstlogarchivedir" ]]
     then

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -337,7 +337,8 @@ static int generate_binlog_index_opt_val(char** ret)
 {
   DBUG_ASSERT(ret);
   *ret= NULL;
-  if (opt_binlog_index_name) {
+  if (opt_bin_log)
+  {
     *ret= strcmp(opt_binlog_index_name, "0") ?
       my_strdup(opt_binlog_index_name, MYF(0)) : my_strdup("", MYF(0));
   }
@@ -1293,7 +1294,9 @@ static int sst_donate_other (const char*        method,
   }
 
   const char* binlog_opt= "";
+  const char* binlog_index_opt= "";
   char* binlog_opt_val= NULL;
+  char* binlog_index_opt_val= NULL;
 
   int ret;
   if ((ret= generate_binlog_opt_val(&binlog_opt_val)))
@@ -1301,7 +1304,15 @@ static int sst_donate_other (const char*        method,
     WSREP_ERROR("sst_donate_other(): generate_binlog_opt_val() failed: %d",ret);
     return ret;
   }
+
+  if ((ret= generate_binlog_index_opt_val(&binlog_index_opt_val)))
+  {
+    WSREP_ERROR("sst_prepare_other(): generate_binlog_index_opt_val() failed %d",
+                ret);
+  }
+
   if (strlen(binlog_opt_val)) binlog_opt= WSREP_SST_OPT_BINLOG;
+  if (strlen(binlog_index_opt_val)) binlog_index_opt= WSREP_SST_OPT_BINLOG_INDEX;
 
   make_wsrep_defaults_file();
 
@@ -1315,15 +1326,18 @@ static int sst_donate_other (const char*        method,
                  WSREP_SST_OPT_DATA " '%s' "
                  " %s "
                  " %s '%s' "
+                 " %s '%s' "
                  WSREP_SST_OPT_GTID " '%s:%lld' "
                  WSREP_SST_OPT_GTID_DOMAIN_ID " '%d'"
                  "%s",
                  method, addr, mysqld_unix_port, mysql_real_data_home,
                  wsrep_defaults_file,
                  binlog_opt, binlog_opt_val,
+                 binlog_index_opt, binlog_index_opt_val,
                  uuid_oss.str().c_str(), gtid.seqno().get(), wsrep_gtid_domain_id,
                  bypass ? " " WSREP_SST_OPT_BYPASS : "");
   my_free(binlog_opt_val);
+  my_free(binlog_index_opt_val);
 
   if (ret < 0 || ret >= cmd_len)
   {
@@ -1397,4 +1411,3 @@ int wsrep_sst_donate(const std::string& msg,
 
   return (ret >= 0 ? 0 : 1);
 }
-  


### PR DESCRIPTION
* Donor node will now provide log-bin-index argument to wsrep_sst_rsync script
* Write correct path and log-bin file names into joiner log-bin-index file
* Extend archive timestamp in mariabackup script 