### PR TITLE
changes related to XA transactions with streaming enabled

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_xa_simple.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_simple.result
@@ -42,3 +42,49 @@ expect 0
 0
 connection node_1;
 DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_2;
+expect empty set
+SELECT * FROM t1;
+f1
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_1;
+XA COMMIT 'test';
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_simple.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_simple.test
@@ -39,3 +39,49 @@ SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 
 --connection node_1
 DROP TABLE t1;
+
+
+#
+# Test B: XA transaction with streaming replication enabled
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+# First fragment should have been replicated
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect empty set
+SELECT * FROM t1;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1a
+# Expect two fragments after XA PREPARE
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+DROP TABLE t1;

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -154,6 +154,13 @@ bool Wsrep_client_service::is_xa() const
   return m_thd->transaction.xid_state.xa_state != XA_NOTR;
 }
 
+bool Wsrep_client_service::is_xa_prepare() const
+{
+  DBUG_ASSERT(m_thd == current_thd);
+  THD* thd= m_thd;
+  return thd->lex->sql_command == SQLCOM_XA_PREPARE;
+}
+
 int Wsrep_client_service::prepare_fragment_for_replication(wsrep::mutable_buffer& buffer)
 {
   DBUG_ASSERT(m_thd == current_thd);

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -55,6 +55,7 @@ public:
   void debug_crash(const char*);
   int bf_rollback();
   bool is_xa() const;
+  bool is_xa_prepare() const;
 private:
   friend class Wsrep_server_service;
   THD* m_thd;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -198,6 +198,12 @@ int Wsrep_high_priority_service::start_transaction(
   DBUG_RETURN(m_thd->wsrep_cs().start_transaction(ws_handle, ws_meta));
 }
 
+int Wsrep_high_priority_service::next_fragment(const wsrep::ws_meta& ws_meta)
+{
+  DBUG_ENTER(" Wsrep_high_priority_service::next_fragment");
+  DBUG_RETURN(m_thd->wsrep_cs().next_fragment(ws_meta));
+}
+
 const wsrep::transaction& Wsrep_high_priority_service::transaction() const
 {
   DBUG_ENTER(" Wsrep_high_priority_service::transaction");

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -35,6 +35,7 @@ public:
   ~Wsrep_high_priority_service();
   int start_transaction(const wsrep::ws_handle&,
                         const wsrep::ws_meta&);
+  int next_fragment(const wsrep::ws_meta&);
   const wsrep::transaction& transaction() const;
   void adopt_transaction(const wsrep::transaction&);
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&) = 0;


### PR DESCRIPTION
- updated `wsrep-lib` submodule
- wsrep_client_service `is_xa_prepare` method
- wsrep_high_priority_service `next_fragment` method
- extended `galera_sr.galera_xa_simple` test