### PR TITLE
fix XA ROLLBACK with streaming enabled

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_xa_rollback.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_rollback.result
@@ -48,3 +48,79 @@ SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 expect 0
 0
 DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA ROLLBACK 'test';
+ERROR XAE07: XAER_RMFAIL: The command cannot be executed when global transaction is in the  ACTIVE state
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_2;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+connection node_2;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1a;
+SELECT * FROM t1;
+f1
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_rollback.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_rollback.test
@@ -56,3 +56,96 @@ SELECT * FROM t1;
 SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 
 DROP TABLE t1;
+
+
+#
+# Test C: Rollback XA transaction before XA END should error
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+--error ER_XAER_RMFAIL
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+
+
+#
+# Test D: Rollback XA transaction after XA PREPARE (streaming replication enabled)
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect two fragments after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test E: Rollback XA transaction before XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+
+--connection node_2
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1a
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -347,12 +347,13 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle& ws_handle,
     // the following may happen if XA ABORT is issued before XA PREPARE
     // in the master.  With streaming turned on, the XA END is
     // only sent to slaves with the XA PREPARE fragment, and the transaction may
-    // still be XA_ACTIVE when the rollback arrives.
+    // still be XA_ACTIVE when the rollback happens.
     // In that case, we issue the XA END here.
-    if (m_thd->transaction.xid_state.xa_state != XA_ACTIVE
-        || !trans_xa_end(m_thd)) {
-        ret= trans_xa_rollback(m_thd);
+    if (m_thd->transaction.xid_state.xa_state == XA_ACTIVE)
+    {
+      trans_xa_end(m_thd);
     }
+    ret= trans_xa_rollback(m_thd);
   }
   m_thd->mdl_context.release_transactional_locks();
   m_thd->mdl_context.release_explicit_locks();

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -344,7 +344,15 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle& ws_handle,
   else
   {
     m_thd->lex->xid= &m_thd->transaction.xid_state.xid;
-    ret= trans_xa_rollback(m_thd);
+    // the following may happen if XA ABORT is issued before XA PREPARE
+    // in the master.  With streaming turned on, the XA END is
+    // only sent to slaves with the XA PREPARE fragment, and the transaction may
+    // still be XA_ACTIVE when the rollback arrives.
+    // In that case, we issue the XA END here.
+    if (m_thd->transaction.xid_state.xa_state != XA_ACTIVE
+        || !trans_xa_end(m_thd)) {
+        ret= trans_xa_rollback(m_thd);
+    }
   }
   m_thd->mdl_context.release_transactional_locks();
   m_thd->mdl_context.release_explicit_locks();


### PR DESCRIPTION
- fixed XA ROLLBACK for streaming transactions, specifically the case
  where the XA ROLLBACK happens before XA PREPARE on the master

- tests for XA ROLLBACK + streaming

- extra test documenting the behaviour of XA ROLLBACK before XA END