### PR TITLE
avoid simple pass through methods in high_priority_service

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -149,32 +149,10 @@ Wsrep_high_priority_service::~Wsrep_high_priority_service()
   thd->wsrep_applier         = m_shadow.wsrep_applier;
 }
 
-int Wsrep_high_priority_service::start_transaction(
-  const wsrep::ws_handle& ws_handle, const wsrep::ws_meta& ws_meta)
+wsrep::client_state& Wsrep_high_priority_service::client_state()
 {
-  DBUG_ENTER(" Wsrep_high_priority_service::start_transaction");
-  DBUG_RETURN(m_thd->wsrep_cs().start_transaction(ws_handle, ws_meta));
+  return m_thd->wsrep_cs();
 }
-
-int Wsrep_high_priority_service::next_fragment(const wsrep::ws_meta& ws_meta)
-{
-  DBUG_ENTER(" Wsrep_high_priority_service::next_fragment");
-  DBUG_RETURN(m_thd->wsrep_cs().next_fragment(ws_meta));
-}
-
-const wsrep::transaction& Wsrep_high_priority_service::transaction() const
-{
-  DBUG_ENTER(" Wsrep_high_priority_service::transaction");
-  DBUG_RETURN(m_thd->wsrep_trx());
-}
-
-void Wsrep_high_priority_service::adopt_transaction(const wsrep::transaction& transaction)
-{
-  DBUG_ENTER(" Wsrep_high_priority_service::adopt_transaction");
-  m_thd->wsrep_cs().adopt_transaction(transaction);
-  DBUG_VOID_RETURN;
-}
-
 
 int Wsrep_high_priority_service::append_fragment_and_commit(
   const wsrep::ws_handle& ws_handle,
@@ -182,7 +160,7 @@ int Wsrep_high_priority_service::append_fragment_and_commit(
   const wsrep::const_buffer& data)
 {
   DBUG_ENTER("Wsrep_high_priority_service::append_fragment_and_commit");
-  int ret= start_transaction(ws_handle, ws_meta);
+  int ret= m_thd->wsrep_cs().start_transaction(ws_handle, ws_meta);
   /*
     Start transaction explicitly to avoid early commit via
     trans_commit_stmt() in append_fragment()

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -33,11 +33,8 @@ class Wsrep_high_priority_service :
 public:
   Wsrep_high_priority_service(THD*);
   ~Wsrep_high_priority_service();
-  int start_transaction(const wsrep::ws_handle&,
-                        const wsrep::ws_meta&);
-  int next_fragment(const wsrep::ws_meta&);
-  const wsrep::transaction& transaction() const;
-  void adopt_transaction(const wsrep::transaction&);
+
+  wsrep::client_state& client_state();
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&) = 0;
   int append_fragment_and_commit(const wsrep::ws_handle&,
                                  const wsrep::ws_meta&,

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -1344,8 +1344,8 @@ int Wsrep_schema::recover_sr_transactions(THD *orig_thd)
         applier= new Wsrep_applier_service(thd);
         server_state.start_streaming_applier(server_id, transaction_id,
                                              applier);
-        applier->start_transaction(wsrep::ws_handle(transaction_id, 0),
-                                   ws_meta);
+        applier->client_state().start_transaction(wsrep::ws_handle(transaction_id, 0),
+                                                  ws_meta);
       }
       applier->store_globals();
       applier->apply_write_set(ws_meta, data);


### PR DESCRIPTION
- new method returning client_state to avoid having simple pass
  through methods to the inner object