### PR TITLE
Fixed replaying bugs found with multimaster load

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -598,7 +598,7 @@ Wsrep_replayer_service::~Wsrep_replayer_service()
   }
   else if (m_replay_status == wsrep::provider::error_certification_failed)
   {
-    DBUG_ASSERT(thd->wsrep_cs().current_error() == wsrep::e_deadlock_error);
+    wsrep_override_error(thd, ER_LOCK_DEADLOCK);
   }
   else
   {


### PR DESCRIPTION
The replayer did not signal replaying waiters. Added
mysql_cond_broadcast() after replaying is over.

Assertion on client error failed after replay attempt failed due
to certification failure. At this point the transaction does not
go through client state, so the client error cannot be overridden.
Assign ER_LOCK_DEADLOCK to thd directly instead.

Use timed cond wait when waiting for replayers to finish and
check if the transaction has been BF aborted during the wait.