### PR TITLE
More sensible timeout values for galera_gtid_2_cluster

### DIFF
--- a/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
@@ -22,7 +22,7 @@ wsrep-sync-wait=15
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep-cluster-address='gcomm://'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.1.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.1.port
@@ -34,7 +34,7 @@ wsrep_sst_receive_address='127.0.0.1:@mysqld.1.#sst_port'
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.2.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
@@ -46,7 +46,7 @@ wsrep_sst_receive_address='127.0.0.1:@mysqld.2.#sst_port'
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.3.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.3.port
@@ -60,7 +60,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep-cluster-address='gcomm://'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.4.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.4.port
@@ -73,7 +73,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.5.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.5.port
@@ -86,7 +86,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.6.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.6.port


### PR DESCRIPTION
Timeout values in galera_2x3nodes.cnf made cluster startup
unreliable. Tweaked timeout values for more reliable cluster start.