### PR TITLE
MTR tests for clearing orphaned SR transactions in Galera

### DIFF
--- a/mysql-test/suite/galera_3nodes_sr/r/galera_sr_threeway_split_no_primary.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/galera_sr_threeway_split_no_primary.result
@@ -1,0 +1,85 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connect node_3a, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+connection node_2;
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (21);
+INSERT INTO t1 VALUES (22);
+connection node_3;
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (31);
+INSERT INTO t1 VALUES (32);
+connection node_2a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+connection node_3a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_3a;
+SET SESSION wsrep_sync_wait = 0;
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_2a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+connection node_3a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+connection node_1a;
+connection node_2a;
+connection node_3a;
+connection node_1a;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+INSERT INTO t1 VALUES(11);
+INSERT INTO t1 VALUES(21);
+INSERT INTO t1 VALUES(31);
+SELECT * FROM t1;
+f1
+11
+21
+31
+connection node_2a;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_3a;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+INSERT INTO t1 VALUES(103);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_2;
+INSERT INTO t1 VALUES(203);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_3;
+INSERT INTO t1 VALUES(303);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_sr_threeway_split_no_primary.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_sr_threeway_split_no_primary.test
@@ -1,0 +1,126 @@
+#
+# This test verifies that an orphaned SR gets cleanup upon cluster
+# reconnection.  Specifically, the case where the cluster goes through
+# a state of no primary components, and the nodes rejoin with the
+# same IDs.
+#
+
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connect node_3a, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+
+--connection node_2
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (21);
+INSERT INTO t1 VALUES (22);
+
+--connection node_3
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (31);
+INSERT INTO t1 VALUES (32);
+
+--connection node_2a
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+
+--connection node_3a
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+
+--connection node_1a
+# wait until cluster is partitioned
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_2a
+# wait until cluster is partitioned
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_3a
+# wait until cluster is partitioned
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_2a
+# reconnect node 2
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+
+--connection node_3a
+# reconnect node 3
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+
+# wait for the cluster to whole again
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+--connection node_2a
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+--connection node_3a
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+--connection node_1a
+# check that the streaming log has been cleared and there are no locks
+# from the SRs by issuing conflicting inserts
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+INSERT INTO t1 VALUES(11);
+INSERT INTO t1 VALUES(21);
+INSERT INTO t1 VALUES(31);
+SELECT * FROM t1;
+
+--connection node_2a
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+--connection node_3a
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+
+# check that all 3 SRs have been rolled back
+--connection node_1
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES(103);
+
+--connection node_2
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES(203);
+
+--connection node_3
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES(303);
+
+--connection node_1
+DROP TABLE t1;
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/r/galera_sr_cc_no_primary.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_cc_no_primary.result
@@ -1,0 +1,70 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+connection node_2;
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (21);
+INSERT INTO t1 VALUES (22);
+SELECT COUNT(*) `expect 6` FROM mysql.wsrep_streaming_log;
+expect 6
+6
+connection node_2a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+SET SESSION wsrep_sync_wait = 0;
+SHOW STATUS LIKE 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	1
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+SHOW STATUS LIKE 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	1
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SET SESSION wsrep_sync_wait = DEFAULT;
+connection node_2a;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+SHOW STATUS LIKE 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2
+connection node_1a;
+SHOW STATUS LIKE 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2a;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+INSERT INTO t1 VALUES(10);
+INSERT INTO t1 VALUES(20);
+SELECT * FROM t1;
+f1
+10
+20
+connection node_1;
+INSERT INTO t1 VALUES(13);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_2;
+INSERT INTO t1 VALUES(23);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_cc_no_primary.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_cc_no_primary.test
@@ -1,0 +1,85 @@
+#
+# This test verifies that an orphaned SR gets cleanup upon cluster
+# reconnection.  Specifically, the case where the cluster goes through
+# a state of no primary components, and the nodes rejoin with the
+# same IDs.
+#
+
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+
+--connection node_2
+SET SESSION wsrep_trx_fragment_size=1;
+BEGIN;
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (21);
+INSERT INTO t1 VALUES (22);
+SELECT COUNT(*) `expect 6` FROM mysql.wsrep_streaming_log;
+
+# isolate node 2
+--connection node_2a
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'OFF' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'OFF' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready'
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_2a
+# reconnect node 2
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 0';
+--source include/galera_wait_ready.inc
+SHOW STATUS LIKE 'wsrep_cluster_size';
+
+--connection node_1a
+# wait for reconnection and check that the streaming log has been cleared
+--source include/galera_wait_ready.inc
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2a
+# check that the streaming log has been cleared and there are no locks
+# from the SRs by issuing conflicting inserts
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+INSERT INTO t1 VALUES(10);
+INSERT INTO t1 VALUES(20);
+SELECT * FROM t1;
+
+# check that both SRs have been rolled back
+--connection node_1
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES(13);
+
+--connection node_2
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES(23);
+
+DROP TABLE t1;
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc


### PR DESCRIPTION
Added a couple of MTR tests which check that streaming transactions
get rolled back when their owners leave the primary component.
Specifically, the tests cover a case in which the cluster moves
between two primary views which have the same membership. This case is
currently not handled properly, the updated version of the `wsrep-lib`
submodule addresses that.