### PR TITLE
MDEV-17099 Support XA transactions for Galera replication

### DIFF
--- a/mysql-test/suite/galera_sr/r/GCF-572.result
+++ b/mysql-test/suite/galera_sr/r/GCF-572.result
@@ -17,8 +17,9 @@ f1	f2
 SET SESSION wsrep_trx_fragment_size = 10000;
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT * FROM mysql.wsrep_streaming_log;
-node_uuid	trx_id	seqno	flags	frag
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+0
 connection node_1a;
 INSERT INTO t1 VALUES(15, 'node2');
 connection node_1;

--- a/mysql-test/suite/galera_sr/r/galera_sr_cc_master.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_cc_master.result
@@ -36,8 +36,6 @@ connection node_2a;
 connection node_1;
 connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2b;
-SELECT * FROM mysql.wsrep_streaming_log;
-node_uuid	trx_id	seqno	flags	frag
 SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 COUNT(*)
 0

--- a/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
@@ -1,0 +1,63 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1;
+SELECT * FROM t1;
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1a;
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1;
+XA END 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+XA END 'test';
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1a;
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1;
+XA PREPARE 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
@@ -12,7 +12,10 @@ f1	f2
 1	node2
 connection node_1;
 SELECT * FROM t1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+XA END 'test';
 ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA ROLLBACK 'test';
 expect (1, node2)
 SELECT * FROM t1;
 f1	f2
@@ -34,6 +37,7 @@ f1	f2
 connection node_1;
 XA END 'test';
 ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA ROLLBACK 'test';
 expect (1, node2)
 SELECT * FROM t1;
 f1	f2
@@ -56,6 +60,7 @@ f1	f2
 connection node_1;
 XA PREPARE 'test';
 ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA ROLLBACK 'test';
 expect (1, node2)
 SELECT * FROM t1;
 f1	f2

--- a/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_bf_abort.result
@@ -66,3 +66,63 @@ SELECT * FROM t1;
 f1	f2
 1	node2
 DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+XA END 'test';
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1a;
+SELECT * FROM t1;
+f1	f2
+1	node2
+connection node_1;
+XA PREPARE 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA COMMIT 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_unit=statements;
+SET SESSION wsrep_trx_fragment_size=3;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node2');
+connection node_1;
+SELECT * FROM t1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+INSERT INTO t1 VALUES (10, 'node1');
+INSERT INTO t1 VALUES (20, 'node1');
+INSERT INTO t1 VALUES (30, 'node1');
+INSERT INTO t1 VALUES (40, 'node1');
+INSERT INTO t1 VALUES (50, 'node1');
+connection node_1;
+XA END 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA ROLLBACK 'test';
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+expect (1, node2)
+SELECT * FROM t1;
+f1	f2
+1	node2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_cert_failure.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_cert_failure.result
@@ -1,0 +1,39 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+connection node_1;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node_1');
+XA END 'test';
+connection node_1a;
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+connection node_2;
+INSERT INTO t1 VALUES (1, 'node_2');
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+connection node_1;
+XA PREPARE 'test';;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+connection node_1;
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+connection node_1;
+SELECT * FROM t1;
+f1	f2
+1	node_2
+connection node_2;
+SELECT * FROM t1;
+f1	f2
+1	node_2
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_cert_failure.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_cert_failure.result
@@ -28,7 +28,7 @@ SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_1;
 ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
-connection node_1;
+XA ROLLBACK 'test';
 SELECT * FROM t1;
 f1	f2
 1	node_2

--- a/mysql-test/suite/galera_sr/r/galera_xa_ddl_conflict.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_ddl_conflict.result
@@ -1,0 +1,54 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+connection node_1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+connection node_2;
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+connection node_1;
+XA END 'test';
+ERROR XA102: XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 9` FROM t1;
+expect 9
+9
+DROP TABLE t1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+connection node_1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+connection node_2;
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
+XA COMMIT 'test';
+SELECT COUNT(*) `expect 10` FROM t1;
+expect 10
+10
+DROP TABLE t1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1b;
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
+XA COMMIT 'test';
+SELECT COUNT(*) `expect 10` FROM t1;
+expect 10
+10
+DROP TABLE t1;
+connection node_1;
+CALL mtr.add_suppression("WSREP: Event 1 Query apply failed");
+connection node_2;
+CALL mtr.add_suppression("WSREP: Event 1 Query apply failed");

--- a/mysql-test/suite/galera_sr/r/galera_xa_failed_commit.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_failed_commit.result
@@ -1,0 +1,79 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1;
+Expect 1 fragment
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+1
+connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2b;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
+connection node_2;
+XA COMMIT 'test';
+ERROR HY000: Got error 6 "No such device or address" during COMMIT
+connection node_2b;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=0';
+connection node_1;
+Expect transaction 'test' to be in prepared state
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+Expect 1 fragment
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+1
+connection node_2b;
+Expect transaction 'test' to be in prepared state
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+disconnect node_2;
+connection node_2b;
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+XA COMMIT 'test';
+connection node_1;
+SELECT * FROM t1;
+f1
+1
+2
+3
+4
+5
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+Expect 0 fragments
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+0
+call mtr.add_suppression('Quorum: No node with complete state');
+connection node_2b;
+SET SESSION wsrep_sync_wait = DEFAULT;
+SELECT * FROM t1;
+f1
+1
+2
+3
+4
+5
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+Expect 0 fragments
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+0
+DROP TABLE t1;
+call mtr.add_suppression('Quorum: No node with complete state');

--- a/mysql-test/suite/galera_sr/r/galera_xa_recover_master.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_recover_master.result
@@ -1,0 +1,72 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+Killing server ...
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+connection node_2a;
+Performing --wsrep-recover ...
+# restart
+connection node_1a;
+connection node_1;
+Expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2;
+Expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2;
+XA COMMIT 'test';
+connection node_1;
+Expect rows 1,2,3
+SELECT * FROM t1;
+f1
+1
+2
+3
+Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+Expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection node_2;
+Expect rows 1,2,3
+SELECT * FROM t1;
+f1
+1
+2
+3
+Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+Expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+connection node_2;
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');

--- a/mysql-test/suite/galera_sr/r/galera_xa_recover_master_rollback.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_recover_master_rollback.result
@@ -1,0 +1,68 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+Killing server ...
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+connection node_2a;
+Performing --wsrep-recover ...
+# restart
+connection node_1a;
+connection node_1;
+Expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2;
+Expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2;
+XA ROLLBACK 'test';
+connection node_1;
+Expect row 1
+SELECT * FROM t1;
+f1
+1
+Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+Expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection node_2;
+Expect row 1
+SELECT * FROM t1;
+f1
+1
+Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+Expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+connection node_2;
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');

--- a/mysql-test/suite/galera_sr/r/galera_xa_rollback.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_rollback.result
@@ -1,0 +1,126 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_2;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA ROLLBACK 'test';
+ERROR XAE07: XAER_RMFAIL: The command cannot be executed when global transaction is in the  ACTIVE state
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_2;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+connection node_2;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1a;
+SELECT * FROM t1;
+f1
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_rollback_streaming.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_rollback_streaming.result
@@ -1,0 +1,131 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+2
+connection node_2;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+2
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+1
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+1
+connection node_1;
+XA ROLLBACK 'test';
+ERROR XAE07: XAER_RMFAIL: The command cannot be executed when global transaction is in the  ACTIVE state
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+1
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+1
+connection node_1;
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_2;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+connection node_2;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1a;
+SELECT * FROM t1;
+f1
+connection node_2;
+SELECT * FROM t1;
+f1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_simple.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_simple.result
@@ -1,0 +1,167 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_2;
+expect empty set
+SELECT * FROM t1;
+f1
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA COMMIT 'test';
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_2;
+expect empty set
+SELECT * FROM t1;
+f1
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+expect 1
+1
+connection node_1;
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+expect 2
+2
+connection node_1;
+XA COMMIT 'test';
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+expect 10
+SELECT * FROM t1;
+f1
+10
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+XA START 'test';
+SELECT * FROM t1;
+f1
+1
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+XA COMMIT 'test';
+DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (30);
+INSERT INTO t1 VALUES (40);
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+expect 4
+4
+connection node_2;
+expect empty set
+SELECT * FROM t1;
+f1
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+expect 4
+4
+connection node_1;
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 5` FROM mysql.wsrep_streaming_log;
+expect 5
+5
+connection node_1;
+XA COMMIT 'test';
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/galera_xa_terminate.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_terminate.result
@@ -1,0 +1,76 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1;
+expect 1
+SELECT * FROM t1;
+f1
+1
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+Killing server ...
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+XA COMMIT 'test';
+expect 1,2,3
+SELECT * FROM t1;
+f1
+1
+2
+3
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+connection node_2a;
+Performing --wsrep-recover ...
+Using --wsrep-start-position when starting mysqld ...
+connection node_1a;
+connection node_2;
+expect 1,2,3
+SELECT * FROM t1;
+f1
+1
+2
+3
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+XA COMMIT 'test';
+ERROR XAE04: XAER_NOTA: Unknown XID
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+connection node_2;
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');

--- a/mysql-test/suite/galera_sr/r/galera_xa_terminate_many_fragments.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_terminate_many_fragments.result
@@ -1,0 +1,76 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SET SESSION wsrep_trx_fragment_size = 1;
+XA START 'test';
+INSERT INTO t1 VALUES (2),(3),(4),(5),(6),(7),(8),(9),(10);
+connection node_1;
+SELECT COUNT(*) `expect 9` FROM mysql.wsrep_streaming_log;
+expect 9
+9
+XA COMMIT 'test';
+ERROR XAE04: XAER_NOTA: Unknown XID
+connection node_2;
+XA END 'test';
+XA PREPARE 'test';
+connection node_1;
+SELECT COUNT(*) `expect 1` FROM t1;
+expect 1
+1
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+Killing server ...
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+XA COMMIT 'test';
+SELECT COUNT(*) `expect 10` FROM t1;
+expect 10
+10
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+connection node_2a;
+Performing --wsrep-recover ...
+Using --wsrep-start-position when starting mysqld ...
+connection node_1a;
+connection node_2;
+SELECT COUNT(*) `expect 10` FROM t1;
+expect 10
+10
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+XA COMMIT 'test';
+ERROR XAE04: XAER_NOTA: Unknown XID
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+connection node_2;
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');

--- a/mysql-test/suite/galera_sr/r/galera_xa_terminate_rollback.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_terminate_rollback.result
@@ -1,0 +1,72 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+connection node_1;
+expect 1
+SELECT * FROM t1;
+f1
+1
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+Killing server ...
+connection node_1a;
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+expect transaction 'test'
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	4	0	test
+XA ROLLBACK 'test';
+expect 1
+SELECT * FROM t1;
+f1
+1
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+connection node_2a;
+Performing --wsrep-recover ...
+Using --wsrep-start-position when starting mysqld ...
+connection node_1a;
+connection node_2;
+expect 1
+SELECT * FROM t1;
+f1
+1
+expect empty set
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+flags	xid
+XA ROLLBACK 'test';
+ERROR XAE04: XAER_NOTA: Unknown XID
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+connection node_2;
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');

--- a/mysql-test/suite/galera_sr/r/galera_xa_xid.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_xid.result
@@ -1,0 +1,101 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+connection node_1;
+XA START 'gtrid';
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid';
+XA PREPARE 'gtrid';
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	5	0	gtrid
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	5	0	gtrid
+connection node_1;
+XA ROLLBACK 'gtrid';
+connection node_1;
+XA START 'gtrid', 'bqaul';
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid', 'bqaul', 1;
+XA PREPARE 'gtrid', 'bqaul';
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	5	5	gtridbqaul
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	5	5	gtridbqaul
+connection node_1;
+XA ROLLBACK 'gtrid', 'bqaul';
+connection node_1;
+XA START 'gtrid', 'bqaul', 2;
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid', 'bqaul', 1;
+XA PREPARE 'gtrid', 'bqaul', 2;
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+2	5	5	gtridbqaul
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+2	5	5	gtridbqaul
+connection node_1;
+XA ROLLBACK 'gtrid', 'bqaul', 2;
+connection node_1;
+XA START X'6162', 0x6364;
+INSERT INTO t1 VALUES (1);
+XA END X'6162', 0x6364;
+XA PREPARE X'6162', 0x6364;
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	2	2	abcd
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	2	2	abcd
+connection node_1;
+XA ROLLBACK X'6162', 0x6364;
+connection node_1;
+XA START 'abc', b'01100001';
+INSERT INTO t1 VALUES (1);
+XA END 'abc', b'01100001';
+XA PREPARE 'abc', b'01100001';
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	3	1	abca
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	3	1	abca
+connection node_1;
+XA ROLLBACK 'abc', b'01100001';
+connection node_1;
+XA START 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+INSERT INTO t1 VALUES (1);
+XA END 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+XA PREPARE 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	14	14	ЁЂЃЄЅІЇЈЉЊЋЌЎЏ
+connection node_2;
+SELECT * FROM t1;
+f1
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+1	14	14	ЁЂЃЄЅІЇЈЉЊЋЌЎЏ
+connection node_1;
+XA ROLLBACK 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/GCF-572.test
+++ b/mysql-test/suite/galera_sr/t/GCF-572.test
@@ -37,7 +37,7 @@ SET SESSION wsrep_trx_fragment_size = 10000;
 
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT * FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 --connection node_1a
 INSERT INTO t1 VALUES(15, 'node2');

--- a/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
@@ -69,7 +69,7 @@ SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 --connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --connection node_2b
 --source include/galera_wait_ready.inc
-SELECT * FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 # Repeat transaction to confirm no locks are left from previous transaction
 

--- a/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
@@ -70,7 +70,6 @@ SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 --connection node_2b
 --source include/galera_wait_ready.inc
 SELECT * FROM mysql.wsrep_streaming_log;
-SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 # Repeat transaction to confirm no locks are left from previous transaction
 

--- a/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
@@ -1,0 +1,84 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+
+#
+# Test A: BF abort XA transaction
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+SELECT * FROM t1;
+
+--echo expect (1, node2)
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+
+#
+# Test B: BF abort XA transaction on XA END
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+
+--connection node_1a
+# sync wait
+SELECT * FROM t1;
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+XA END 'test';
+
+--echo expect (1, node2)
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+
+#
+# Test C: BF abort XA transaction on XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+XA END 'test';
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+
+--connection node_1a
+# sync wait
+SELECT * FROM t1;
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+XA PREPARE 'test';
+
+--echo expect (1, node2)
+SELECT * FROM t1;
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
@@ -18,8 +18,12 @@ INSERT INTO t1 VALUES (1, 'node2');
 SELECT * FROM t1;
 
 --connection node_1
---error ER_XA_RBDEADLOCK
+--error ER_LOCK_DEADLOCK
 SELECT * FROM t1;
+
+--error ER_XA_RBDEADLOCK
+XA END 'test';
+XA ROLLBACK 'test';
 
 --echo expect (1, node2)
 SELECT * FROM t1;
@@ -48,6 +52,7 @@ SELECT * FROM t1;
 --connection node_1
 --error ER_XA_RBDEADLOCK
 XA END 'test';
+XA ROLLBACK 'test';
 
 --echo expect (1, node2)
 SELECT * FROM t1;
@@ -77,6 +82,7 @@ SELECT * FROM t1;
 --connection node_1
 --error ER_XA_RBDEADLOCK
 XA PREPARE 'test';
+XA ROLLBACK 'test';
 
 --echo expect (1, node2)
 SELECT * FROM t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_bf_abort.test
@@ -88,3 +88,76 @@ XA ROLLBACK 'test';
 SELECT * FROM t1;
 
 DROP TABLE t1;
+
+
+#
+# Test D: Attempt XA COMMIT after BF abort
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+XA END 'test';
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node2');
+SELECT * FROM t1;
+
+--connection node_1a
+# sync wait
+SELECT * FROM t1;
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+XA PREPARE 'test';
+--error ER_XA_RBDEADLOCK
+XA COMMIT 'test';
+
+--echo expect (1, node2)
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+
+#
+# Test E: BF abort with streaming
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+SET SESSION wsrep_trx_fragment_unit=statements;
+SET SESSION wsrep_trx_fragment_size=3;
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node1');
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node2');
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+SELECT * FROM t1;
+
+INSERT INTO t1 VALUES (10, 'node1');
+INSERT INTO t1 VALUES (20, 'node1');
+INSERT INTO t1 VALUES (30, 'node1');
+INSERT INTO t1 VALUES (40, 'node1');
+INSERT INTO t1 VALUES (50, 'node1');
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+XA END 'test';
+XA ROLLBACK 'test';
+
+--echo expect (1, node2)
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect (1, node2)
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_cert_failure.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_cert_failure.test
@@ -1,0 +1,69 @@
+#
+# Test certification failure on XA PREPARE
+#
+
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(64)) ENGINE=InnoDB;
+
+--connection node_1
+XA START 'test';
+INSERT INTO t1 VALUES (1, 'node_1');
+XA END 'test';
+
+#
+# Issue conflicting operation on node_2 and block it in apply monitor
+# (this transaction is certified, but not applied yet)
+#
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+INSERT INTO t1 VALUES (1, 'node_2');
+
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+#
+# Issue XA PREPARE and wait for it to replicate (it will fail certification)
+#
+--let $galera_sync_point = after_replicate_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--send XA PREPARE 'test';
+
+--connection node_1a
+--let $galera_sync_point = after_replicate_sync apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+#
+# Release both threads
+#
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+--let $galera_sync_point = after_replicate_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+#
+# XA PREPARE is expected to report certification failure
+#
+--connection node_1
+--error ER_XA_RBDEADLOCK
+--reap
+
+--connection node_1
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_cert_failure.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_cert_failure.test
@@ -60,7 +60,7 @@ INSERT INTO t1 VALUES (1, 'node_2');
 --error ER_XA_RBDEADLOCK
 --reap
 
---connection node_1
+XA ROLLBACK 'test';
 SELECT * FROM t1;
 
 --connection node_2

--- a/mysql-test/suite/galera_sr/t/galera_xa_ddl_conflict.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_ddl_conflict.test
@@ -1,0 +1,82 @@
+#
+# Test DDL vs XA conflicts
+#
+
+--source include/galera_cluster.inc
+
+#
+# Test A: DDL BF aborts active XA (before XA PREPARE)
+#
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+--connection node_1
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+
+--connection node_2
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+
+--connection node_1
+--error ER_XA_RBDEADLOCK
+XA END 'test';
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 9` FROM t1;
+DROP TABLE t1;
+
+
+#
+# Test B: DDL attempts to BF abort prepared XA
+#
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+--connection node_1
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_2
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+
+--connection node_1
+XA COMMIT 'test';
+
+SELECT COUNT(*) `expect 10` FROM t1;
+DROP TABLE t1;
+
+#
+# Test C: local DDL vs prepared XA conflict
+#
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+--connection node_1
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1b
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t1 ADD COLUMN (f2 INTEGER);
+
+--connection node_1
+XA COMMIT 'test';
+
+SELECT COUNT(*) `expect 10` FROM t1;
+DROP TABLE t1;
+
+--connection node_1
+CALL mtr.add_suppression("WSREP: Event 1 Query apply failed");
+
+--connection node_2
+CALL mtr.add_suppression("WSREP: Event 1 Query apply failed");

--- a/mysql-test/suite/galera_sr/t/galera_xa_failed_commit.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_failed_commit.test
@@ -1,0 +1,112 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+#
+# Test a transient failure on XA COMMIT
+# The test uses gmcast.isolate to temporarily drop the node out
+# of the cluster, while a XA COMMIT is attempted.
+#
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1
+--echo Expect 1 fragment
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+
+
+#
+# Disconnect node_2 from the group
+#
+--connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2b
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'non-Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+
+#
+# Client fails to XA COMMIT the transaction while 'non-Primary'
+#
+--connection node_2
+--error ER_ERROR_DURING_COMMIT
+XA COMMIT 'test';
+
+#
+# Reconnect node_2 to the group
+#
+--connection node_2b
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=0';
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+
+--echo Expect transaction 'test' to be in prepared state
+XA RECOVER;
+--echo Expect 1 fragment
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+
+--connection node_2b
+--echo Expect transaction 'test' to be in prepared state
+XA RECOVER;
+
+#
+# The following `disconnect` is a workaround due to
+# wsrep_trans_xa_detach() not working as expected.
+# Remove the line once the issue is fixed.
+#
+--disconnect node_2
+
+#
+# XA COMMIT should now complete
+#
+--connection node_2b
+XA RECOVER;
+XA COMMIT 'test';
+
+#
+# Check that the transaction is committed and cleanup
+#
+--connection node_1
+SELECT * FROM t1;
+XA RECOVER;
+--echo Expect 0 fragments
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+
+call mtr.add_suppression('Quorum: No node with complete state');
+
+
+--connection node_2b
+SET SESSION wsrep_sync_wait = DEFAULT;
+SELECT * FROM t1;
+XA RECOVER;
+--echo Expect 0 fragments
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+call mtr.add_suppression('Quorum: No node with complete state');

--- a/mysql-test/suite/galera_sr/t/galera_xa_recover_master.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_recover_master.test
@@ -1,0 +1,123 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+#
+# Test recovery of XA prepared transaction
+#
+# The master of XA transaction is killed after successful XA PREPARE. Upon
+# recovery it is expected that the transaction is still is prepared, and
+# master can issue XA COMMIT to terminate the transaction.
+#
+
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+--connection node_2
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+
+#
+# Create XA transaction 'test' and up to prepare phase
+#
+--connection node_2
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+
+
+#
+# Kill the node and restart it
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2a
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Trx 'test' should still be there
+#
+--connection node_1
+--echo Expect transaction 'test'
+XA RECOVER;
+
+--connection node_2
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--echo Expect transaction 'test'
+XA RECOVER;
+
+
+#
+# XA COMMIT after recovery should succeed
+#
+--connection node_2
+XA COMMIT 'test';
+
+
+#
+# No more traces of 'test'
+#
+--connection node_1
+--echo Expect rows 1,2,3
+SELECT * FROM t1;
+--echo Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--echo Expect empty set
+XA RECOVER;
+
+--connection node_2
+--echo Expect rows 1,2,3
+SELECT * FROM t1;
+--echo Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--echo Expect empty set
+XA RECOVER;
+
+
+#
+# Cleanup
+#
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+
+--connection node_2
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/t/galera_xa_recover_master_rollback.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_recover_master_rollback.test
@@ -1,0 +1,123 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+#
+# Test recovery of XA prepared transaction
+#
+# The master of XA transaction is killed after successful XA PREPARE. Upon
+# recovery it is expected that the transaction is still is prepared, and
+# master can issue XA ROLLBACK to terminate the transaction.
+#
+
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+--connection node_2
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+
+#
+# Create XA transaction 'test' and up to prepare phase
+#
+--connection node_2
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+
+
+#
+# Kill the node and restart it
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2a
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Trx 'test' should still be there
+#
+--connection node_1
+--echo Expect transaction 'test'
+XA RECOVER;
+
+--connection node_2
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--echo Expect transaction 'test'
+XA RECOVER;
+
+
+#
+# XA ROLLBACK after recovery should succeed
+#
+--connection node_2
+XA ROLLBACK 'test';
+
+
+#
+# No more traces of 'test'
+#
+--connection node_1
+--echo Expect row 1
+SELECT * FROM t1;
+--echo Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--echo Expect empty set
+XA RECOVER;
+
+--connection node_2
+--echo Expect row 1
+SELECT * FROM t1;
+--echo Expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--echo Expect empty set
+XA RECOVER;
+
+
+#
+# Cleanup
+#
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+
+--connection node_2
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/t/galera_xa_rollback.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_rollback.test
@@ -1,0 +1,151 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+#
+# Test A: Rollback XA transaction after XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect a fragment after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test B: Rollback XA transaction before XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test C: Rollback XA transaction before XA END should error
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+--error ER_XAER_RMFAIL
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+
+
+#
+# Test D: Rollback XA transaction after XA PREPARE (streaming replication enabled)
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect two fragments after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test E: Rollback XA transaction before XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+
+--connection node_2
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1a
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_rollback_streaming.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_rollback_streaming.test
@@ -1,0 +1,160 @@
+#
+# Tests for XA rollback with streaming enabled
+#
+
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+#
+# Test A: Rollback XA transaction after XA PREPARE
+#
+
+--connection node_1
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect a fragment after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test B: Rollback XA transaction before XA PREPARE
+#
+
+--connection node_1
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test C: Rollback XA transaction before XA END should error
+#
+
+--connection node_1
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+--error ER_XAER_RMFAIL
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA ROLLBACK 'test';
+DROP TABLE t1;
+
+
+#
+# Test D: Rollback XA transaction after XA PREPARE (streaming replication enabled)
+#
+
+--connection node_1
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect two fragments after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;
+
+
+#
+# Test E: Rollback XA transaction before XA PREPARE
+#
+
+--connection node_1
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (1);
+XA END 'test';
+
+--connection node_2
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA ROLLBACK 'test';
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1a
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_simple.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_simple.test
@@ -1,0 +1,163 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+#
+# Test A: XA transaction replicates a fragment on XA PREPARE
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+XA END 'test';
+XA PREPARE 'test';
+
+# Expect one fragment after XA PREPARE
+--connection node_1a
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect empty set
+SELECT * FROM t1;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+DROP TABLE t1;
+
+
+#
+# Test B: XA transaction with streaming replication enabled
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+# First fragment should have been replicated
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect empty set
+SELECT * FROM t1;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 1` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1a
+# Expect two fragments after XA PREPARE
+SELECT COUNT(*) `expect 2` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect 10
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+# unset fragmentation
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;
+
+
+#
+# Test C: Read-only XA does not replicate
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+XA START 'test';
+SELECT * FROM t1;
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1a
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+
+DROP TABLE t1;
+
+
+#
+# Test D: XA transaction with streaming replication enabled, multiple
+# fragments before XA prepare.
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (30);
+INSERT INTO t1 VALUES (40);
+# Four fragments should have been replicated
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect empty set
+SELECT * FROM t1;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1a
+# Another fragment after XA PREPARE
+SELECT COUNT(*) `expect 5` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+# unset fragmentation
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_terminate.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_terminate.test
@@ -1,0 +1,127 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+
+#
+# Test termination of prepared XA transaction on behalf of another
+# node in the cluster.
+#
+
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+--connection node_2
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+
+#
+# Create XA transaction 'test' up to prepared state
+#
+--connection node_2
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+
+
+#
+# Verify that transaction 'test' is in prepared state in node_1
+#
+--connection node_1
+--echo expect 1
+SELECT * FROM t1;
+--echo expect transaction 'test'
+XA RECOVER;
+
+
+#
+# Kill node_2 and wait for the cluster to shrink
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Transaction 'test' is still in prepared state
+# and we can commit it.
+#
+--connection node_1
+--echo expect transaction 'test'
+XA RECOVER;
+XA COMMIT 'test';
+
+--echo expect 1,2,3
+SELECT * FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+
+
+#
+# Recover node_2 and wait for it to rejoin
+#
+--connection node_2a
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source suite/galera/include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Check that 'test' is committed
+#
+--connection node_2
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--echo expect 1,2,3
+SELECT * FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--error ER_XAER_NOTA
+XA COMMIT 'test';
+
+
+#
+# Cleanup
+#
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+
+--connection node_2
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');
+
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/t/galera_xa_terminate_many_fragments.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_terminate_many_fragments.test
@@ -1,0 +1,140 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+
+#
+# Test termination of prepared XA transaction, with multiple fragments,
+# on behalf of another node in the cluster.
+#
+
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+--connection node_2
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+
+#
+# Create XA transaction 'test' and generate a bunch of fragments
+#
+--connection node_2
+SET SESSION wsrep_trx_fragment_size = 1;
+XA START 'test';
+INSERT INTO t1 VALUES (2),(3),(4),(5),(6),(7),(8),(9),(10);
+
+
+#
+# Commit is not possible before XA PREPARE
+#
+--connection node_1
+SELECT COUNT(*) `expect 9` FROM mysql.wsrep_streaming_log;
+--error ER_XAER_NOTA
+XA COMMIT 'test';
+
+
+#
+# Prepare 'test'
+#
+--connection node_2
+XA END 'test';
+XA PREPARE 'test';
+
+
+#
+# Verify that transaction 'test' is in prepared state in node_1
+#
+--connection node_1
+SELECT COUNT(*) `expect 1` FROM t1;
+
+--echo expect transaction 'test'
+XA RECOVER;
+
+
+#
+# Kill node_2 and wait for the cluster to shrink
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Transaction 'test' is still in prepared state
+# and we can commit it on behalf of connection node_2
+#
+--connection node_1
+--echo expect transaction 'test'
+XA RECOVER;
+XA COMMIT 'test';
+
+SELECT COUNT(*) `expect 10` FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+
+
+#
+# Recover node_2 and wait for it to rejoin
+#
+--connection node_2a
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source suite/galera/include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Check that 'test' is committed
+#
+--connection node_2
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+SELECT COUNT(*) `expect 10` FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--error ER_XAER_NOTA
+XA COMMIT 'test';
+
+
+#
+# Cleanup
+#
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+
+--connection node_2
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');
+
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/t/galera_xa_terminate_rollback.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_terminate_rollback.test
@@ -1,0 +1,127 @@
+--source include/galera_cluster.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+
+#
+# Test termination of prepared XA transaction on behalf of another
+# node in the cluster.
+#
+
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+--connection node_2
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+
+#
+# Create XA transaction 'test' up to prepared state
+#
+--connection node_2
+XA START 'test';
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+XA END 'test';
+XA PREPARE 'test';
+
+
+#
+# Verify that transaction 'test' is in prepared state in node_1
+#
+--connection node_1
+--echo expect 1
+SELECT * FROM t1;
+--echo expect transaction 'test'
+XA RECOVER;
+
+
+#
+# Kill node_2 and wait for the cluster to shrink
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Transaction 'test' is still in prepared state
+# and we can rollback.
+#
+--connection node_1
+--echo expect transaction 'test'
+XA RECOVER;
+XA ROLLBACK 'test';
+
+--echo expect 1
+SELECT * FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+
+
+#
+# Recover node_2 and wait for it to rejoin
+#
+--connection node_2a
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source suite/galera/include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+#
+# Check that 'test' is rolled back
+#
+--connection node_2
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--echo expect 1
+SELECT * FROM t1;
+--echo expect empty set
+XA RECOVER;
+--echo expect empty set
+SELECT flags, xid FROM mysql.wsrep_streaming_log;
+--error ER_XAER_NOTA
+XA ROLLBACK 'test';
+
+
+#
+# Cleanup
+#
+--connection node_1
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+
+--connection node_2
+DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+call mtr.add_suppression('Found 1 prepared XA transactions');
+call mtr.add_suppression('Discovered discontinuity in recovered wsrep transaction XIDs.');
+
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_sr/t/galera_xa_xid.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_xid.test
@@ -1,0 +1,125 @@
+#
+# Test that the output of XA RECOVER shows the same xid on master and slaves
+#
+
+--source include/galera_cluster.inc
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+#
+# Test A: xid contains gtrid
+#
+
+--connection node_1
+XA START 'gtrid';
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid';
+XA PREPARE 'gtrid';
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK 'gtrid';
+
+
+#
+# Test B: xid contains gtrid and bqual
+#
+
+--connection node_1
+XA START 'gtrid', 'bqaul';
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid', 'bqaul', 1;
+XA PREPARE 'gtrid', 'bqaul';
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK 'gtrid', 'bqaul';
+
+
+#
+# Test C: xid contains gtrid, bqual and format id
+#
+
+--connection node_1
+XA START 'gtrid', 'bqaul', 2;
+INSERT INTO t1 VALUES (1);
+XA END 'gtrid', 'bqaul', 1;
+XA PREPARE 'gtrid', 'bqaul', 2;
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK 'gtrid', 'bqaul', 2;
+
+
+#
+# Test D: xid using hex format
+#
+
+--connection node_1
+XA START X'6162', 0x6364;
+INSERT INTO t1 VALUES (1);
+XA END X'6162', 0x6364;
+XA PREPARE X'6162', 0x6364;
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK X'6162', 0x6364;
+
+
+#
+# Test E: xid using bit format
+#
+
+--connection node_1
+XA START 'abc', b'01100001';
+INSERT INTO t1 VALUES (1);
+XA END 'abc', b'01100001';
+XA PREPARE 'abc', b'01100001';
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK 'abc', b'01100001';
+
+
+#
+# Test F: xid using unicode characters
+#
+
+--connection node_1
+# xid with Cyrillic characters
+XA START 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+INSERT INTO t1 VALUES (1);
+XA END 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+XA PREPARE 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+XA RECOVER;
+
+--connection node_2
+SELECT * FROM t1;
+XA RECOVER;
+
+--connection node_1
+XA ROLLBACK 'ЁЂЃЄЅІЇ', 'ЈЉЊЋЌЎЏ';
+
+
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1241,6 +1241,16 @@ static int prepare_or_error(handlerton *ht, THD *thd, bool all)
   if (run_wsrep_hooks && ht->flags & HTON_WSREP_REPLICATION &&
       wsrep_before_prepare(thd, all))
   {
+    if (thd->transaction.xid_state.is_explicit_XA())
+    {
+      /*
+        If XA is BF aborted here, then the following rollback
+        is going to clear the xa_state. So must we must set
+        the error here because it may be specific to XA
+        (i.e. ER_XA_RBDEADLOCK vs ER_LOCK_DEADLOCK)
+      */
+      wsrep_override_current_error(thd);
+    }
     return(1);
   }
 #endif /* WITH_WSREP */

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1243,13 +1243,7 @@ static int prepare_or_error(handlerton *ht, THD *thd, bool all)
   {
     if (thd->transaction.xid_state.is_explicit_XA())
     {
-      /*
-        If XA is BF aborted here, then the following rollback
-        is going to clear the xa_state. So must we must set
-        the error here because it may be specific to XA
-        (i.e. ER_XA_RBDEADLOCK vs ER_LOCK_DEADLOCK)
-      */
-      wsrep_override_current_error(thd);
+      thd->transaction.xid_state.set_error(ER_LOCK_DEADLOCK);
     }
     return(1);
   }

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -10768,13 +10768,13 @@ bool wsrep_stmt_rollback_is_safe(THD* thd)
     binlog_cache_data * trx_cache = &cache_mngr->trx_cache;
     if (thd->wsrep_sr().fragments_certified() > 0 &&
         (trx_cache->get_prev_position() == MY_OFF_T_UNDEF ||
-         trx_cache->get_prev_position() < thd->wsrep_sr().bytes_certified()))
+         trx_cache->get_prev_position() < thd->wsrep_sr().log_position()))
     {
       WSREP_DEBUG("statement rollback is not safe for streaming replication"
                   " pre-stmt_pos: %llu, frag repl pos: %zu\n"
                   "Thread: %llu, SQL: %s",
                   trx_cache->get_prev_position(),
-                  thd->wsrep_sr().bytes_certified(),
+                  thd->wsrep_sr().log_position(),
                   thd->thread_id, thd->query());
        ret = false;
     }

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -1766,7 +1766,11 @@ MDL_lock::can_grant_lock(enum_mdl_type type_arg,
             requestor_ctx->get_thd()->wsrep_cs().mode() ==
             wsrep::client_state::m_rsu)
         {
-          wsrep_handle_mdl_conflict(requestor_ctx, ticket, &key);
+          if (!wsrep_handle_mdl_conflict(requestor_ctx, ticket, &key))
+          {
+            my_error(ER_LOCK_DEADLOCK, MYF(0));
+            break;
+          }
           if (wsrep_log_conflicts)
           {
             auto key= ticket->get_key();
@@ -2265,6 +2269,23 @@ MDL_context::acquire_lock(MDL_request *mdl_request, double lock_wait_timeout)
     has MDL_lock::m_rwlock write-locked.
   */
   lock= ticket->m_lock;
+
+#ifdef WITH_WSREP
+  if (WSREP(get_thd()) &&
+      get_thd()->get_stmt_da()->is_error() &&
+      get_thd()->get_stmt_da()->sql_errno() == ER_LOCK_DEADLOCK)
+  {
+    /*
+      Attempt to acquire lock resulted in a deadlock error.
+      This happens when there is a MDL conflict between DDL
+      and XA transaction in prepared state.
+      The DDL must be retried.
+    */
+    mysql_prlock_unlock(&lock->m_rwlock);
+    MDL_ticket::destroy(ticket);
+    DBUG_RETURN(TRUE);
+  }
+#endif /* WITH_WSREP */
 
   if (lock_wait_timeout == 0)
   {

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1297,9 +1297,15 @@ bool do_command(THD *thd)
     thd->store_globals();
     WSREP_LOG_THD(thd, "enter found BF aborted");
     DBUG_ASSERT(!thd->mdl_context.has_locks());
-    /* We let COM_QUIT and COM_STMT_CLOSE to execute even if wsrep aborted. */
+    /*
+       We let COM_QUIT and COM_STMT_CLOSE to execute even if wsrep aborted.
+       XA statements need to go through as well, so that the transaction
+       transitions to XA_ROLLLBACK_ONLY state, and is explicitly rolled
+       back by the client.
+    */
     if (command != COM_STMT_CLOSE &&
-        command != COM_QUIT)
+        command != COM_QUIT &&
+        !thd->transaction.xid_state.is_explicit_XA())
     {
       wsrep_override_error(thd, ER_LOCK_DEADLOCK);
 
@@ -2399,6 +2405,10 @@ dispatch_end:
         ))
   {
     wsrep_override_current_error(thd);
+    if (thd->transaction.xid_state.is_explicit_XA())
+    {
+      thd->wsrep_cs().reset_error();
+    }
     WSREP_LOG_THD(thd, "leave");
   }
   if (WSREP(thd))

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1297,12 +1297,12 @@ bool do_command(THD *thd)
     thd->store_globals();
     WSREP_LOG_THD(thd, "enter found BF aborted");
     DBUG_ASSERT(!thd->mdl_context.has_locks());
-    DBUG_ASSERT(!thd->get_stmt_da()->is_set());
     /* We let COM_QUIT and COM_STMT_CLOSE to execute even if wsrep aborted. */
     if (command != COM_STMT_CLOSE &&
         command != COM_QUIT)
     {
-      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      wsrep_override_error(thd, ER_LOCK_DEADLOCK);
+
       WSREP_DEBUG("Deadlock error for: %s", thd->query());
       thd->reset_killed();
       thd->mysys_var->abort     = 0;
@@ -2398,9 +2398,7 @@ dispatch_end:
         command == COM_STMT_CLOSE
         ))
   {
-    /* todo: Pass wsrep client state current error to override */
-    wsrep_override_error(thd, wsrep_current_error(thd),
-                         wsrep_current_error_status(thd));
+    wsrep_override_current_error(thd);
     WSREP_LOG_THD(thd, "leave");
   }
   if (WSREP(thd))
@@ -3785,9 +3783,9 @@ mysql_execute_command(THD *thd)
     start a multi STMT transaction, the wsrep_transaction is
     committed as empty at the end of this function.
 
-    Transaction is started for BEGIN in trans_begin(), for DDL the
-    implicit commit took care of committing previous transaction
-    above and a new transaction should not be started.
+    For BEGIN and XA_START transaction is started in trans_begin().
+    For DDL the implicit commit took care of committing previous
+    transaction above and a new transaction should not be started.
 
     Do not start transaction for stored procedures, it will be handled
     internally in SP processing.
@@ -3795,6 +3793,7 @@ mysql_execute_command(THD *thd)
   if (WSREP(thd)                          &&
       wsrep_thd_is_local(thd)             &&
       lex->sql_command != SQLCOM_BEGIN    &&
+      lex->sql_command != SQLCOM_XA_START &&
       lex->sql_command != SQLCOM_CALL     &&
       lex->sql_command != SQLCOM_EXECUTE  &&
       !(sql_command_flags[lex->sql_command] & CF_AUTO_COMMIT_TRANS))

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -24,8 +24,10 @@
 #include "wsrep_trans_observer.h"
 
 #include "slave.h" // opt_log_slave_updates
+#include "rpl_mi.h" // Master_info
 #include "log_event.h" // class THD, EVENT_LEN_OFFSET, etc.
 #include "debug_sync.h"
+#include <string.h>
 
 /*
   read the first event from (*buf). The size of the (*buf) is (*buf_len).
@@ -176,6 +178,19 @@ int wsrep_apply_events(THD*        thd,
       }
     }
 #endif /* GTID_SUPPORT */
+    case QUERY_EVENT:
+      if (!strncmp(((Query_log_event*)ev)->query, STRING_WITH_LEN("XA START")))
+      {
+        // We are going to explicitly start a transaction using
+        // XA START. Streaming applier thd's are in active multi
+        // statement transaction by default, but trans_xa_start()
+        // will fail if find the thd already in that state.
+        // Consider introducing a specialized streaming applier
+        // which takes this into account.
+        thd->variables.option_bits&= ~OPTION_BEGIN;
+        thd->server_status&= ~SERVER_STATUS_IN_TRANS;
+      }
+      break;
     default:
       break;
     }
@@ -213,6 +228,7 @@ int wsrep_apply_events(THD*        thd,
     event++;
 
     delete_or_keep_event_post_apply(thd->wsrep_rgi, typ, ev);
+    wsrep_set_apply_format(thd, NULL);
   }
 
 error:
@@ -222,4 +238,46 @@ error:
   wsrep_set_apply_format(thd, NULL);
 
   DBUG_RETURN(rcode);
+}
+
+rpl_group_info* wsrep_relay_group_init(THD* thd, const char* log_fname)
+{
+  Relay_log_info* rli= new Relay_log_info(false);
+
+  if (!rli->relay_log.description_event_for_exec)
+  {
+    rli->relay_log.description_event_for_exec=
+      new Format_description_log_event(4);
+  }
+
+  static LEX_CSTRING connection_name= { STRING_WITH_LEN("wsrep") };
+
+  /*
+    Master_info's constructor initializes rpl_filter by either an already
+    constructed Rpl_filter object from global 'rpl_filters' list if the
+    specified connection name is same, or it constructs a new Rpl_filter
+    object and adds it to rpl_filters. This object is later destructed by
+    Mater_info's destructor by looking it up based on connection name in
+    rpl_filters list.
+
+    However, since all Master_info objects created here would share same
+    connection name ("wsrep"), destruction of any of the existing Master_info
+    objects (in wsrep_return_from_bf_mode()) would free rpl_filter referenced
+    by any/all existing Master_info objects.
+
+    In order to avoid that, we have added a check in Master_info's destructor
+    to not free the "wsrep" rpl_filter. It will eventually be freed by
+    free_all_rpl_filters() when server terminates.
+  */
+  rli->mi= new Master_info(&connection_name, false);
+
+  struct rpl_group_info *rgi= new rpl_group_info(rli);
+  rgi->thd= rli->sql_driver_thd= thd;
+
+  if ((rgi->deferred_events_collecting= rli->mi->rpl_filter->is_on()))
+  {
+    rgi->deferred_events= new Deferred_log_events(rli);
+  }
+
+  return rgi;
 }

--- a/sql/wsrep_applier.h
+++ b/sql/wsrep_applier.h
@@ -70,4 +70,6 @@ int wsrep_apply(void*                   ctx,
 wsrep_cb_status_t wsrep_unordered_cb(void*              ctx,
                                      const wsrep_buf_t* data);
 
+rpl_group_info* wsrep_relay_group_init(THD* thd, const char* log_fname);
+
 #endif /* WSREP_APPLIER_H */

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -123,7 +123,7 @@ static int wsrep_write_cache_inc(THD*      const thd,
   DBUG_ENTER("wsrep_write_cache_inc");
   my_off_t const saved_pos(my_b_tell(cache));
 
-  if (reinit_io_cache(cache, READ_CACHE, thd->wsrep_sr().bytes_certified(), 0, 0))
+  if (reinit_io_cache(cache, READ_CACHE, thd->wsrep_sr().log_position(), 0, 0))
   {
     WSREP_ERROR("failed to initialize io-cache");
     DBUG_RETURN(1);;
@@ -158,7 +158,7 @@ static int wsrep_write_cache_inc(THD*      const thd,
   }
   if (ret == 0)
   {
-    assert(total_length + thd->wsrep_sr().bytes_certified() == saved_pos);
+    assert(total_length + thd->wsrep_sr().log_position() == saved_pos);
   }
 
 cleanup:

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -55,6 +55,14 @@ Wsrep_client_service::Wsrep_client_service(THD* thd,
   , m_client_state(client_state)
 { }
 
+std::string Wsrep_client_service::query() const
+{
+  if (m_thd->query())
+    return m_thd->query();
+  else
+    return "";
+}
+
 void Wsrep_client_service::store_globals()
 {
   DBUG_ENTER("Wsrep_client_service::store_globals");
@@ -141,12 +149,59 @@ void Wsrep_client_service::cleanup_transaction()
   m_thd->wsrep_affected_rows= 0;
 }
 
+bool Wsrep_client_service::is_xa() const
+{
+  return m_thd->transaction.xid_state.is_explicit_XA();
+}
 
-int Wsrep_client_service::prepare_fragment_for_replication(wsrep::mutable_buffer& buffer)
+bool Wsrep_client_service::is_xa_prepare() const
+{
+  DBUG_ASSERT(m_thd == current_thd);
+  return m_thd->lex->sql_command == SQLCOM_XA_PREPARE;
+}
+
+std::string Wsrep_client_service::xid() const
+{
+  if (is_xa())
+  {
+    std::string xid;
+    wsrep_get_sql_xid(m_thd->transaction.xid_state.get_xid(), xid);
+    return xid;
+  }
+  return "";
+}
+
+static int write_xa_event_helper(THD* thd,
+                                 const char* query,
+                                 size_t query_len,
+                                 wsrep::mutable_buffer& buffer)
+{
+  std::string stmt;
+  stmt.append(query, query_len);
+  wsrep_get_sql_xid(thd->transaction.xid_state.get_xid(), stmt);
+
+  uchar* event_buf= NULL;
+  size_t event_buf_len= 0;
+  wsrep_to_buf_helper(thd, stmt.c_str(), stmt.length(),
+                      &event_buf, &event_buf_len);
+  buffer.push_back(reinterpret_cast<const char*>(event_buf),
+                   reinterpret_cast<const char*>(event_buf + event_buf_len));
+  my_free(event_buf);
+  return 0;
+}
+
+int Wsrep_client_service::prepare_fragment_for_replication(
+  wsrep::mutable_buffer& buffer, size_t& log_position)
 {
   DBUG_ASSERT(m_thd == current_thd);
   THD* thd= m_thd;
   DBUG_ENTER("Wsrep_client_service::prepare_fragment_for_replication");
+
+  if (is_xa() && thd->wsrep_sr().fragments_certified() == 0)
+  {
+    write_xa_event_helper(thd, STRING_WITH_LEN("XA START "), buffer);
+  }
+
   IO_CACHE* cache= wsrep_get_trans_cache(thd);
   thd->binlog_flush_pending_rows_event(true);
 
@@ -156,13 +211,13 @@ int Wsrep_client_service::prepare_fragment_for_replication(wsrep::mutable_buffer
   }
 
   const my_off_t saved_pos(my_b_tell(cache));
-  if (reinit_io_cache(cache, READ_CACHE, thd->wsrep_sr().bytes_certified(), 0, 0))
+  if (reinit_io_cache(cache, READ_CACHE, thd->wsrep_sr().log_position(), 0, 0))
   {
     DBUG_RETURN(1);
   }
 
   int ret= 0;
-  size_t total_length= 0;
+  size_t total_length= buffer.size();
   size_t length= my_b_bytes_in_cache(cache);
 
   if (!length)
@@ -190,6 +245,14 @@ int Wsrep_client_service::prepare_fragment_for_replication(wsrep::mutable_buffer
     while (cache->file >= 0 && (length= my_b_fill(cache)));
   }
   DBUG_ASSERT(total_length == buffer.size());
+
+  if (is_xa_prepare())
+  {
+    write_xa_event_helper(thd, STRING_WITH_LEN("XA END "), buffer);
+    write_xa_event_helper(thd, STRING_WITH_LEN("XA PREPARE "), buffer);
+  }
+
+  log_position = saved_pos;
 cleanup:
   if (reinit_io_cache(cache, WRITE_CACHE, saved_pos, 0, 0))
   {
@@ -319,8 +382,17 @@ int Wsrep_client_service::bf_rollback()
 {
   DBUG_ASSERT(m_thd == current_thd);
   DBUG_ENTER("Wsrep_client_service::rollback");
-
-  int ret= (trans_rollback_stmt(m_thd) || trans_rollback(m_thd));
+  int ret(1);
+  if (is_xa())
+  {
+    m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
+    ret= wsrep_trans_xa_end_and_rollback(m_thd);
+    wsrep_override_error(m_thd, ER_XA_RBDEADLOCK);
+  }
+  else
+  {
+    ret= (trans_rollback_stmt(m_thd) || trans_rollback(m_thd));
+  }
   if (m_thd->locked_tables_mode && m_thd->lock)
   {
     m_thd->locked_tables_list.unlock_locked_tables(m_thd);

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -381,13 +381,12 @@ void Wsrep_client_service::debug_crash(const char* crash_point)
 int Wsrep_client_service::bf_rollback()
 {
   DBUG_ASSERT(m_thd == current_thd);
-  DBUG_ENTER("Wsrep_client_service::rollback");
+  DBUG_ENTER("Wsrep_client_service::bf_rollback");
   int ret(1);
   if (is_xa())
   {
-    m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
-    ret= wsrep_trans_xa_end_and_rollback(m_thd);
-    wsrep_override_error(m_thd, ER_XA_RBDEADLOCK);
+    m_thd->transaction.xid_state.set_error(ER_LOCK_DEADLOCK);
+    ret= ha_rollback_trans(m_thd, true);
   }
   else
   {

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -54,9 +54,6 @@ public:
   void debug_sync(const char*);
   void debug_crash(const char*);
   int bf_rollback();
-  bool is_xa() const;
-  bool is_xa_prepare() const;
-  std::string xid() const;
 private:
   friend class Wsrep_server_service;
   THD* m_thd;

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -36,6 +36,7 @@ class Wsrep_client_service : public wsrep::client_service
 public:
   Wsrep_client_service(THD*, Wsrep_client_state&);
 
+  std::string query() const;
   bool interrupted(wsrep::unique_lock<wsrep::mutex>&) const;
   void reset_globals();
   void store_globals();
@@ -43,7 +44,7 @@ public:
   void cleanup_transaction();
   bool statement_allowed_for_streaming() const;
   size_t bytes_generated() const;
-  int prepare_fragment_for_replication(wsrep::mutable_buffer&);
+  int prepare_fragment_for_replication(wsrep::mutable_buffer&, size_t&);
   int remove_fragments();
   void emergency_shutdown()
   { throw wsrep::not_implemented_error(); }
@@ -53,6 +54,9 @@ public:
   void debug_sync(const char*);
   void debug_crash(const char*);
   int bf_rollback();
+  bool is_xa() const;
+  bool is_xa_prepare() const;
+  std::string xid() const;
 private:
   friend class Wsrep_server_service;
   THD* m_thd;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -263,7 +263,7 @@ int Wsrep_high_priority_service::commit(const wsrep::ws_handle& ws_handle,
   int ret;
   if (m_thd->wsrep_trx().state() == wsrep::transaction::s_prepared)
   {
-    if (m_thd->wsrep_trx().is_xa())
+    if (m_thd->transaction.xid_state.is_explicit_XA())
     {
       m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
     }
@@ -318,7 +318,7 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle& ws_handle,
   if (m_thd->wsrep_trx().is_xa() ||
       m_thd->wsrep_trx().state() == wsrep::transaction::s_prepared)
   {
-    if (m_thd->wsrep_trx().is_xa())
+    if (m_thd->transaction.xid_state.is_explicit_XA())
     {
       m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
     }

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -62,48 +62,6 @@ private:
 };
 }
 
-static rpl_group_info* wsrep_relay_group_init(THD* thd, const char* log_fname)
-{
-  Relay_log_info* rli= new Relay_log_info(false);
-
-  if (!rli->relay_log.description_event_for_exec)
-  {
-    rli->relay_log.description_event_for_exec=
-      new Format_description_log_event(4);
-  }
-
-  static LEX_CSTRING connection_name= { STRING_WITH_LEN("wsrep") };
-
-  /*
-    Master_info's constructor initializes rpl_filter by either an already
-    constructed Rpl_filter object from global 'rpl_filters' list if the
-    specified connection name is same, or it constructs a new Rpl_filter
-    object and adds it to rpl_filters. This object is later destructed by
-    Mater_info's destructor by looking it up based on connection name in
-    rpl_filters list.
-
-    However, since all Master_info objects created here would share same
-    connection name ("wsrep"), destruction of any of the existing Master_info
-    objects (in wsrep_return_from_bf_mode()) would free rpl_filter referenced
-    by any/all existing Master_info objects.
-
-    In order to avoid that, we have added a check in Master_info's destructor
-    to not free the "wsrep" rpl_filter. It will eventually be freed by
-    free_all_rpl_filters() when server terminates.
-  */
-  rli->mi= new Master_info(&connection_name, false);
-
-  struct rpl_group_info *rgi= new rpl_group_info(rli);
-  rgi->thd= rli->sql_driver_thd= thd;
-
-  if ((rgi->deferred_events_collecting= rli->mi->rpl_filter->is_on()))
-  {
-    rgi->deferred_events= new Deferred_log_events(rli);
-  }
-
-  return rgi;
-}
-
 static void wsrep_setup_uk_and_fk_checks(THD* thd)
 {
   /* Tune FK and UK checking policy. These are reset back to original
@@ -199,6 +157,12 @@ int Wsrep_high_priority_service::start_transaction(
               trans_begin(m_thd));
 }
 
+int Wsrep_high_priority_service::next_fragment(const wsrep::ws_meta& ws_meta)
+{
+  DBUG_ENTER(" Wsrep_high_priority_service::next_fragment");
+  DBUG_RETURN(m_thd->wsrep_cs().next_fragment(ws_meta));
+}
+
 const wsrep::transaction& Wsrep_high_priority_service::transaction() const
 {
   DBUG_ENTER(" Wsrep_high_priority_service::transaction");
@@ -225,7 +189,8 @@ int Wsrep_high_priority_service::adopt_transaction(
 int Wsrep_high_priority_service::append_fragment_and_commit(
   const wsrep::ws_handle& ws_handle,
   const wsrep::ws_meta& ws_meta,
-  const wsrep::const_buffer& data)
+  const wsrep::const_buffer& data,
+  const std::string& xid)
 {
   DBUG_ENTER("Wsrep_high_priority_service::append_fragment_and_commit");
   int ret= start_transaction(ws_handle, ws_meta);
@@ -239,7 +204,8 @@ int Wsrep_high_priority_service::append_fragment_and_commit(
                                             ws_meta.transaction_id(),
                                             ws_meta.seqno(),
                                             ws_meta.flags(),
-                                            data);
+                                            data,
+                                            xid);
 
   /*
     Note: The commit code below seems to be identical to
@@ -288,22 +254,34 @@ int Wsrep_high_priority_service::commit(const wsrep::ws_handle& ws_handle,
                                         const wsrep::ws_meta& ws_meta)
 {
   DBUG_ENTER("Wsrep_high_priority_service::commit");
-  THD* thd= m_thd;
-  DBUG_ASSERT(thd->wsrep_trx().active());
-  thd->wsrep_cs().prepare_for_ordering(ws_handle, ws_meta, true);
-  thd_proc_info(thd, "committing");
+  DBUG_ASSERT(m_thd->wsrep_trx().active());
+
+  m_thd->wsrep_cs().prepare_for_ordering(ws_handle, ws_meta, true);
+  thd_proc_info(m_thd, "committing");
 
   const bool is_ordered= !ws_meta.seqno().is_undefined();
-  int ret= trans_commit(thd);
+  int ret;
+  if (m_thd->wsrep_trx().state() == wsrep::transaction::s_prepared)
+  {
+    if (m_thd->wsrep_trx().is_xa())
+    {
+      m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
+    }
+    ret= trans_xa_commit(m_thd);
+  }
+  else
+  {
+    ret= trans_commit(m_thd);
+  }
 
   if (ret == 0)
   {
-    m_rgi->cleanup_context(thd, 0);
+    m_rgi->cleanup_context(m_thd, 0);
   }
 
   m_thd->mdl_context.release_transactional_locks();
 
-  thd_proc_info(thd, "wsrep applier committed");
+  thd_proc_info(m_thd, "wsrep applier committed");
 
   if (!is_ordered)
   {
@@ -319,13 +297,13 @@ int Wsrep_high_priority_service::commit(const wsrep::ws_handle& ws_handle,
 
       This is a workaround for CTAS with empty result set.
     */
-    WSREP_DEBUG("Commit not finished for applier %llu", thd->thread_id);
+    WSREP_DEBUG("Commit not finished for applier %llu", m_thd->thread_id);
     ret= ret || m_thd->wsrep_cs().before_commit() ||
       m_thd->wsrep_cs().ordered_commit() ||
       m_thd->wsrep_cs().after_commit();
   }
 
-  thd->lex->sql_command= SQLCOM_END;
+  m_thd->lex->sql_command= SQLCOM_END;
 
   must_exit_= check_exit_status();
   DBUG_RETURN(ret);
@@ -336,7 +314,20 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle& ws_handle,
 {
   DBUG_ENTER("Wsrep_high_priority_service::rollback");
   m_thd->wsrep_cs().prepare_for_ordering(ws_handle, ws_meta, false);
-  int ret= (trans_rollback_stmt(m_thd) || trans_rollback(m_thd));
+  int ret(1);
+  if (m_thd->wsrep_trx().is_xa() ||
+      m_thd->wsrep_trx().state() == wsrep::transaction::s_prepared)
+  {
+    if (m_thd->wsrep_trx().is_xa())
+    {
+      m_thd->lex->xid= m_thd->transaction.xid_state.get_xid();
+    }
+    ret= wsrep_trans_xa_end_and_rollback(m_thd);
+  }
+  else
+  {
+    ret= (trans_rollback_stmt(m_thd) || trans_rollback(m_thd));
+  }
   m_thd->mdl_context.release_transactional_locks();
   m_thd->mdl_context.release_explicit_locks();
   DBUG_RETURN(ret);
@@ -474,7 +465,9 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta& ws_meta,
   thd->variables.option_bits |= OPTION_BEGIN;
   thd->variables.option_bits |= OPTION_NOT_AUTOCOMMIT;
   DBUG_ASSERT(thd->wsrep_trx().active());
-  DBUG_ASSERT(thd->wsrep_trx().state() == wsrep::transaction::s_executing);
+  DBUG_ASSERT(thd->wsrep_trx().state() == wsrep::transaction::s_executing ||
+              (thd->wsrep_trx().state() == wsrep::transaction::s_prepared &&
+               thd->wsrep_trx().is_xa()));
 
   thd_proc_info(thd, "applying write set");
   /* moved dbug sync point here, after possible THD switch for SR transactions

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -137,6 +137,13 @@ public:
     m_thd->transaction.xid_state.xid_cache_element= 0;
     DBUG_RETURN(Wsrep_applier_service::rollback(ws_handle, ws_meta));
   }
+  int adopt_transaction(const wsrep::transaction& transaction)
+  {
+    DBUG_ENTER("Wsrep_prepared_applier_service::adopt_transaction");
+    m_thd->wsrep_cs().adopt_transaction(transaction);
+    int ret= wsrep_trans_xa_attach(m_thd, &m_xid);
+    DBUG_RETURN(ret);
+  }
 private:
   XID m_xid;
 };

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2078,13 +2078,15 @@ void wsrep_to_isolation_end(THD *thd)
   @retval TRUE   Lock request can be granted
   @retval FALSE  Lock request cannot be granted
 */
-
-void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
+bool wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
                                MDL_ticket *ticket,
                                const MDL_key *key)
 {
+  bool ret(TRUE);
+
   /* Fallback to the non-wsrep behaviour */
-  if (!WSREP_ON) return;
+  if (!WSREP_ON)
+    return ret;
 
   THD *request_thd= requestor_ctx->get_thd();
   THD *granted_thd= ticket->get_ctx()->get_thd();
@@ -2107,10 +2109,21 @@ void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
     {
       if (wsrep_thd_is_SR(granted_thd) && !wsrep_thd_is_SR(request_thd))
       {
-        WSREP_MDL_LOG(INFO, "MDL conflict, DDL vs SR", 
-                      schema, schema_len, request_thd, granted_thd);
-        mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
-        wsrep_abort_thd((void*)request_thd, (void*)granted_thd, 1);
+        if (granted_thd->wsrep_trx().state() ==
+            wsrep::transaction::s_prepared)
+        {
+          WSREP_MDL_LOG(DEBUG, "MDL conflict, DDL vs prepared XA",
+                        schema, schema_len, request_thd, granted_thd);
+          mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
+          ret= FALSE;
+        }
+        else
+        {
+          WSREP_MDL_LOG(DEBUG, "MDL conflict, DDL vs SR",
+                        schema, schema_len, request_thd, granted_thd);
+          mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
+          wsrep_abort_thd((void*)request_thd, (void*)granted_thd, 1);
+        }
       }
       else
       {
@@ -2138,13 +2151,24 @@ void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
     }
     else
     {
-      WSREP_MDL_LOG(DEBUG, "MDL conflict-> BF abort", schema, schema_len,
-                    request_thd, granted_thd);
       ticket->wsrep_report(wsrep_debug);
       if (granted_thd->wsrep_trx().active())
       {
-        mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
-        wsrep_abort_thd(request_thd, granted_thd, 1);
+        if (granted_thd->wsrep_trx().state() ==
+            wsrep::transaction::s_prepared)
+        {
+          WSREP_MDL_LOG(DEBUG, "MDL conflict, DDL vs prepared XA",
+                        schema, schema_len, request_thd, granted_thd);
+          mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
+          ret= FALSE;
+        }
+        else
+        {
+          WSREP_MDL_LOG(DEBUG, "MDL conflict-> BF abort",
+                        schema, schema_len, request_thd, granted_thd);
+          mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
+          wsrep_abort_thd(request_thd, granted_thd, 1);
+        }
       }
       else
       {
@@ -2171,6 +2195,8 @@ void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
   {
     mysql_mutex_unlock(&request_thd->LOCK_thd_data);
   }
+
+  return ret;
 }
 
 /**/

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1399,10 +1399,8 @@ int wsrep_to_buf_helper(
   enum enum_binlog_checksum_alg current_binlog_check_alg=
     (enum_binlog_checksum_alg) binlog_checksum_options;
 
-  Format_description_log_event *tmp_fd= new Format_description_log_event(4);
-  tmp_fd->checksum_alg= current_binlog_check_alg;
-  writer.write(tmp_fd);
-  delete tmp_fd;
+  Format_description_log_event tmp_fd(BINLOG_VERSION);
+  tmp_fd.checksum_alg= current_binlog_check_alg;
 
 #ifdef GTID_SUPPORT
   if (thd->variables.gtid_next.type == GTID_GROUP)
@@ -1414,6 +1412,7 @@ int wsrep_to_buf_helper(
 #endif /* GTID_SUPPORT */
   if (wsrep_gtid_mode && thd->variables.gtid_seq_no)
   {
+    if (writer.write(&tmp_fd)) ret= 1;
     Gtid_log_event gtid_event(thd, thd->variables.gtid_seq_no,
                           thd->variables.gtid_domain_id,
                           true, LOG_EVENT_SUPPRESS_USE_F,
@@ -1426,6 +1425,7 @@ int wsrep_to_buf_helper(
   /* if there is prepare query, add event for it */
   if (!ret && thd->wsrep_TOI_pre_query)
   {
+    if (writer.write(&tmp_fd)) ret= 1;
     Query_log_event ev(thd, thd->wsrep_TOI_pre_query,
 		       thd->wsrep_TOI_pre_query_len,
 		       FALSE, FALSE, FALSE, 0);
@@ -1433,6 +1433,7 @@ int wsrep_to_buf_helper(
     if (writer.write(&ev)) ret= 1;
   }
 
+  if (writer.write(&tmp_fd)) ret= 1;
   /* continue to append the actual query */
   Query_log_event ev(thd, query, query_len, FALSE, FALSE, FALSE, 0);
   ev.checksum_alg= current_binlog_check_alg;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -385,7 +385,7 @@ bool wsrep_prepare_keys_for_isolation(THD*              thd,
                                       wsrep_key_arr_t*  ka);
 void wsrep_keys_free(wsrep_key_arr_t* key_arr);
 
-extern void
+extern bool
 wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
                           MDL_ticket *ticket,
                           const MDL_key *key);

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -86,6 +86,7 @@ static const std::string create_frag_table_str=
   "seqno BIGINT, "
   "flags INT NOT NULL, "
   "frag LONGBLOB NOT NULL, "
+  "xid VARCHAR(256) NOT NULL,"
   "PRIMARY KEY (node_uuid, trx_id, seqno)"
   ") ENGINE=InnoDB";
 
@@ -476,6 +477,13 @@ static int scan(TABLE* table, uint field, char* strbuf, uint strbuf_len)
   (void)table->field[field]->val_str(&str);
   strncpy(strbuf, str.c_ptr(), std::min(str.length(), strbuf_len));
   strbuf[strbuf_len - 1]= '\0';
+  return 0;
+}
+
+static int scan(TABLE* table, uint field, String& str)
+{
+  assert(field < table->s->fields);
+  (void)table->field[field]->val_str(&str);
   return 0;
 }
 
@@ -881,7 +889,8 @@ int Wsrep_schema::append_fragment(THD* thd,
                                   wsrep::transaction_id transaction_id,
                                   wsrep::seqno seqno,
                                   int flags,
-                                  const wsrep::const_buffer& data)
+                                  const wsrep::const_buffer& data,
+                                  const std::string& xid)
 {
   DBUG_ENTER("Wsrep_schema::append_fragment");
   std::ostringstream os;
@@ -905,6 +914,7 @@ int Wsrep_schema::append_fragment(THD* thd,
   Wsrep_schema_impl::store(frag_table, 2, seqno.get());
   Wsrep_schema_impl::store(frag_table, 3, flags);
   Wsrep_schema_impl::store(frag_table, 4, data.data(), data.size());
+  Wsrep_schema_impl::store(frag_table, 5, xid);
 
   int error;
   if ((error= Wsrep_schema_impl::insert(frag_table))) {
@@ -1315,10 +1325,13 @@ int Wsrep_schema::recover_sr_transactions(THD *orig_thd)
       wsrep::gtid gtid(cluster_id, seqno);
       int flags;
       Wsrep_schema_impl::scan(frag_table, 3, flags);
-      String data_str;
 
-      (void)frag_table->field[4]->val_str(&data_str);
+      String data_str;
+      Wsrep_schema_impl::scan(frag_table, 4, data_str);
       wsrep::const_buffer data(data_str.c_ptr_quick(), data_str.length());
+      String frag_xid;
+      Wsrep_schema_impl::scan(frag_table, 5, frag_xid);
+
       wsrep::ws_meta ws_meta(gtid,
                              wsrep::stid(server_id,
                                          transaction_id,
@@ -1331,17 +1344,29 @@ int Wsrep_schema::recover_sr_transactions(THD *orig_thd)
                                                          transaction_id)))
       {
         DBUG_ASSERT(wsrep::starts_transaction(flags));
+
         THD* thd= new THD(next_thread_id(), true);
         thd->thread_stack= (char*)&storage_thd;
-
         thd->real_id= pthread_self();
 
-        applier= new Wsrep_applier_service(thd);
-        server_state.start_streaming_applier(server_id, transaction_id,
+        XID xid;
+        const std::string xid_match(frag_xid.c_ptr(), frag_xid.length());
+        if (frag_xid.length() &&
+            wsrep_find_prepared_xid(thd, xid_match, &xid))
+        {
+          applier= new Wsrep_prepared_applier_service(thd, &xid);
+        }
+        else
+        {
+          applier= new Wsrep_applier_service(thd);
+        }
+        server_state.start_streaming_applier(server_id,
+                                             transaction_id,
                                              applier);
         applier->start_transaction(wsrep::ws_handle(transaction_id, 0),
                                    ws_meta);
       }
+
       applier->store_globals();
       wsrep::mutable_buffer unused;
       applier->apply_write_set(ws_meta, data, unused);

--- a/sql/wsrep_schema.h
+++ b/sql/wsrep_schema.h
@@ -79,7 +79,8 @@ class Wsrep_schema
                       wsrep::transaction_id transaction_id,
                       wsrep::seqno seqno,
                       int flags,
-                      const wsrep::const_buffer& data);
+                      const wsrep::const_buffer& data,
+                      const std::string& xid);
   /**
      Update existing fragment meta data. The fragment must have been
      inserted before using append_fragment().

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -32,6 +32,10 @@
 #include "transaction.h" /* trans_xxx */
 #include "sql_base.h" /* close_thread_tables */
 
+#include "rpl_rli.h"
+#include "rpl_mi.h"
+#include "wsrep_applier.h" /* wsrep_relay_group_init() */
+
 static void init_service_thd(THD* thd, char* thread_stack)
 {
   thd->thread_stack= thread_stack;
@@ -96,6 +100,14 @@ Wsrep_server_service::streaming_applier_service(
     orig_hps(static_cast<Wsrep_high_priority_service&>(orig_high_priority_service));
   THD* thd= new THD(next_thread_id(), true);
   init_service_thd(thd, orig_hps.m_thd->thread_stack);
+
+  if (!thd->wsrep_rgi)
+  {
+    thd->wsrep_rgi= wsrep_relay_group_init(thd, "wsrep_relay");
+    thd->system_thread_info.rpl_sql_info=
+      new rpl_sql_thread_info(thd->wsrep_rgi->rli->mi->rpl_filter);
+  }
+
   WSREP_DEBUG("Created streaming applier service in high priority "
               "context with thread id %llu", thd->thread_id);
   return new Wsrep_applier_service(thd);
@@ -107,6 +119,16 @@ void Wsrep_server_service::release_high_priority_service(wsrep::high_priority_se
     static_cast<Wsrep_high_priority_service*>(high_priority_service);
   THD* thd= hps->m_thd;
   delete hps;
+  if (thd->wsrep_rgi)
+  {
+    delete thd->system_thread_info.rpl_sql_info;
+    delete thd->wsrep_rgi->rli->mi;
+    delete thd->wsrep_rgi->rli;
+
+    thd->wsrep_rgi->cleanup_after_session();
+    delete thd->wsrep_rgi;
+    thd->wsrep_rgi= NULL;
+  }
   delete thd;
 }
 

--- a/sql/wsrep_storage_service.cc
+++ b/sql/wsrep_storage_service.cc
@@ -100,7 +100,8 @@ void Wsrep_storage_service::adopt_transaction(const wsrep::transaction& transact
 int Wsrep_storage_service::append_fragment(const wsrep::id& server_id,
                                            wsrep::transaction_id transaction_id,
                                            int flags,
-                                           const wsrep::const_buffer& data)
+                                           const wsrep::const_buffer& data,
+                                           const std::string& xid)
 {
   DBUG_ENTER("Wsrep_storage_service::append_fragment");
   DBUG_ASSERT(m_thd == current_thd);
@@ -111,7 +112,8 @@ int Wsrep_storage_service::append_fragment(const wsrep::id& server_id,
                                          transaction_id,
                                          wsrep::seqno(-1),
                                          flags,
-                                         data);
+                                         data,
+                                         xid);
   DBUG_RETURN(ret);
 }
 

--- a/sql/wsrep_storage_service.h
+++ b/sql/wsrep_storage_service.h
@@ -33,7 +33,8 @@ public:
   int append_fragment(const wsrep::id&,
                       wsrep::transaction_id,
                       int flags,
-                      const wsrep::const_buffer&);
+                      const wsrep::const_buffer&,
+                      const std::string&);
   int update_fragment_meta(const wsrep::ws_meta&);
   int remove_fragments();
   int commit(const wsrep::ws_handle&, const wsrep::ws_meta&);

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -177,10 +177,16 @@ static inline void wsrep_override_error(THD* thd,
     wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
     break;
   case wsrep::e_deadlock_error:
-    if (thd->transaction.xid_state.is_explicit_XA())
+    switch (thd->lex->sql_command)
+    {
+    case SQLCOM_XA_END:
+    case SQLCOM_XA_PREPARE:
       wsrep_override_error(thd, ER_XA_RBDEADLOCK);
-    else
+      break;
+    default:
       wsrep_override_error(thd, ER_LOCK_DEADLOCK);
+      break;
+    }
     break;
   case wsrep::e_interrupted_error:
     wsrep_override_error(thd, ER_QUERY_INTERRUPTED);

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -99,6 +99,18 @@ extern void  wsrep_thd_set_PA_safe(void *thd_ptr, my_bool safe);
 THD* wsrep_start_SR_THD(char *thread_stack);
 void wsrep_end_SR_THD(THD* thd);
 
+
+static inline enum wsrep::client_error wsrep_current_error(THD* thd)
+{
+  return thd->wsrep_cs().current_error();
+}
+
+static inline enum wsrep::provider::status
+wsrep_current_error_status(THD* thd)
+{
+  return thd->wsrep_cs().current_error_status();
+}
+
 /**
    Helper functions to override error status
 
@@ -124,7 +136,8 @@ static inline void wsrep_override_error(THD *thd, uint error)
       (da->is_error() &&
        da->sql_errno() != error &&
        da->sql_errno() != ER_ERROR_DURING_COMMIT &&
-       da->sql_errno() != ER_LOCK_DEADLOCK))
+       da->sql_errno() != ER_LOCK_DEADLOCK &&
+       da->sql_errno() != ER_XA_RBDEADLOCK))
   {
     da->reset_diagnostics_area();
     my_error(error, MYF(0));
@@ -143,7 +156,8 @@ static inline void wsrep_override_error(THD *thd, uint error,
       (da->is_error() &&
        da->sql_errno() != error &&
        da->sql_errno() != ER_ERROR_DURING_COMMIT &&
-       da->sql_errno() != ER_LOCK_DEADLOCK))
+       da->sql_errno() != ER_LOCK_DEADLOCK &&
+       da->sql_errno() != ER_XA_RBDEADLOCK))
   {
     da->reset_diagnostics_area();
     my_error(error, MYF(0), status);
@@ -154,35 +168,44 @@ static inline void wsrep_override_error(THD* thd,
                                         wsrep::client_error ce,
                                         enum wsrep::provider::status status)
 {
-    DBUG_ASSERT(ce != wsrep::e_success);
-    switch (ce)
-    {
-    case wsrep::e_error_during_commit:
-      wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
-      break;
-    case wsrep::e_deadlock_error:
+  switch (ce)
+  {
+  case wsrep::e_success:
+    DBUG_ASSERT(0);
+    break;
+  case wsrep::e_error_during_commit:
+    wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
+    break;
+  case wsrep::e_deadlock_error:
+    if (thd->transaction.xid_state.is_explicit_XA())
+      wsrep_override_error(thd, ER_XA_RBDEADLOCK);
+    else
       wsrep_override_error(thd, ER_LOCK_DEADLOCK);
-      break;
-    case wsrep::e_interrupted_error:
-      wsrep_override_error(thd, ER_QUERY_INTERRUPTED);
-      break;
-    case wsrep::e_size_exceeded_error:
-      wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
-      break;
-    case wsrep::e_append_fragment_error:
-      /* TODO: Figure out better error number */
-      wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
-      break;
-    case wsrep::e_not_supported_error:
-      wsrep_override_error(thd, ER_NOT_SUPPORTED_YET);
-      break;
-    case wsrep::e_timeout_error:
-      wsrep_override_error(thd, ER_LOCK_WAIT_TIMEOUT);
-      break;
-    default:
-      wsrep_override_error(thd, ER_UNKNOWN_ERROR);
-      break;
-    }
+    break;
+  case wsrep::e_interrupted_error:
+    wsrep_override_error(thd, ER_QUERY_INTERRUPTED);
+    break;
+  case wsrep::e_size_exceeded_error:
+    wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
+    break;
+  case wsrep::e_append_fragment_error:
+    /* TODO: Figure out better error number */
+    wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, status);
+    break;
+  case wsrep::e_not_supported_error:
+    wsrep_override_error(thd, ER_NOT_SUPPORTED_YET);
+    break;
+  case wsrep::e_timeout_error:
+    wsrep_override_error(thd, ER_LOCK_WAIT_TIMEOUT);
+    break;
+  }
+}
+
+static inline void wsrep_override_current_error(THD* thd)
+{
+  wsrep_override_error(thd,
+                       wsrep_current_error(thd),
+                       wsrep_current_error_status(thd));
 }
 
 /**

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -22,6 +22,7 @@
 #include "wsrep_xid.h"
 #include "wsrep_thd.h"
 #include "wsrep_binlog.h" /* register/deregister group commit */
+#include "wsrep_high_priority_service.h"
 #include "my_dbug.h"
 
 class THD;
@@ -152,6 +153,47 @@ static inline int wsrep_start_trx_if_not_started(THD* thd)
 }
 
 /*
+  Helper method to determine if a transaction must terminate
+  a prepared XA by XID (possibly on behalf of another node).
+
+  Return true if the caller must call wsrep_commit_or_rollback_by_xid,
+  false otherwise.
+ */
+static inline bool wsrep_must_commit_or_rollback_by_xid(THD* thd)
+{
+  bool ret= false;
+  if (!thd->wsrep_applier)
+  {
+    std::string xid;
+    wsrep_get_sql_xid(thd->lex->xid, xid);
+    Wsrep_server_state& server_state(Wsrep_server_state::instance());
+    wsrep::high_priority_service* sa(server_state.find_streaming_applier(xid));
+    if (sa)
+    {
+      ret= (sa->transaction().state() == wsrep::transaction::s_prepared);
+    }
+  }
+  return ret;
+}
+
+/*
+  Commits or rolls back transaction with the given xid.
+  This is used in the case where prepared XA transaction
+  is terminated on behalf of another node which failed or
+  went non-Primary.
+
+  Return zero on success, non-zero on failures.
+ */
+static inline int wsrep_commit_or_rollback_by_xid(THD* thd,
+                                                  bool commit)
+{
+  DBUG_ASSERT(!thd->wsrep_applier);
+  std::string xid;
+  wsrep_get_sql_xid(thd->lex->xid, xid);
+  return thd->wsrep_cs().commit_or_rollback_by_xid(xid, commit);
+}
+
+/*
   Called after each row operation.
 
   Return zero on succes, non-zero on failure.
@@ -229,9 +271,12 @@ static inline int wsrep_before_prepare(THD* thd, bool all)
   DBUG_ASSERT(wsrep_run_commit_hook(thd, all));
   if ((ret= thd->wsrep_cs().before_prepare()) == 0)
   {
-    DBUG_ASSERT(!thd->wsrep_trx().ws_meta().gtid().is_undefined());
-    wsrep_xid_init(&thd->wsrep_xid,
+    if (!thd->wsrep_trx().is_xa())
+    {
+      DBUG_ASSERT(!thd->wsrep_trx().ws_meta().gtid().is_undefined());
+      wsrep_xid_init(&thd->wsrep_xid,
                      thd->wsrep_trx().ws_meta().gtid());
+    }
   }
   DBUG_RETURN(ret);
 }
@@ -454,18 +499,6 @@ static inline void wsrep_after_command_ignore_result(THD* thd)
   DBUG_ASSERT(!thd->wsrep_cs().current_error());
   wsrep_after_command_after_result(thd);
 }
-
-static inline enum wsrep::client_error wsrep_current_error(THD* thd)
-{
-  return thd->wsrep_cs().current_error();
-}
-
-static inline enum wsrep::provider::status
-wsrep_current_error_status(THD* thd)
-{
-  return thd->wsrep_cs().current_error_status();
-}
-
 
 /*
   Commit an empty transaction.

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -152,6 +152,20 @@ static inline int wsrep_start_trx_if_not_started(THD* thd)
   return ret;
 }
 
+static inline void wsrep_assign_xid(THD* thd)
+{
+  std::string xid;
+  wsrep_get_sql_xid(thd->lex->xid, xid);
+  thd->wsrep_cs().assign_xid(xid);
+}
+
+static inline bool wsrep_restore_prepared_transaction(THD* thd, XID* xid)
+{
+  std::string xid_string;
+  wsrep_get_sql_xid(xid, xid_string);
+  return thd->wsrep_cs().restore_xid(xid_string);
+}
+
 /*
   Helper method to determine if a transaction must terminate
   a prepared XA by XID (possibly on behalf of another node).

--- a/sql/xa.h
+++ b/sql/xa.h
@@ -42,3 +42,12 @@ bool trans_xa_commit(THD *thd);
 bool trans_xa_rollback(THD *thd);
 bool trans_xa_detach(THD *thd);
 bool mysql_xa_recover(THD *thd);
+
+#ifdef WITH_WSREP
+bool wsrep_trans_xa_attach(THD *thd, XID *xid);
+bool wsrep_trans_xa_end_and_rollback(THD *thd);
+void wsrep_get_sql_xid(XID *xid, std::string &xid_string);
+bool wsrep_find_prepared_xid(THD *thd,
+                             const std::string &xid_string,
+                             XID *xid);
+#endif /* WITH_WSREP */


### PR DESCRIPTION
This patch adds XA support for Galera replication.
XA is implemented on top of the streaming replication feature. An XA
transaction is replicated in two steps: first, a fragment is
replicated when XA PREPARE is issued. If the first fragment is
successfully replicated, then XA PREPARE succeeds, and the transaction
is active cluster-wide and is no longer vulnerable to multi-master
conflicts.
In the second phase, when XA COMMIT or XA ROLLBACK is issued, one more
fragment is replicated which will commit / rollback the transaction in
the cluster.
To workaround the limitation of missing XA specific log events in
MariaDB, we "inject" query log events for XA statements (XA START, XA
END, XA PREPARE) into galera replication stream.