### PR TITLE
change use of `bytes_certified` to `log_position`

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_xa_simple.result
+++ b/mysql-test/suite/galera_sr/r/galera_xa_simple.result
@@ -109,3 +109,59 @@ expect 0
 connection node_1;
 XA COMMIT 'test';
 DROP TABLE t1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (30);
+INSERT INTO t1 VALUES (40);
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+expect 4
+4
+connection node_2;
+expect empty set
+SELECT * FROM t1;
+f1
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+expect 4
+4
+connection node_1;
+XA END 'test';
+XA PREPARE 'test';
+connection node_1a;
+SELECT COUNT(*) `expect 5` FROM mysql.wsrep_streaming_log;
+expect 5
+5
+connection node_1;
+XA COMMIT 'test';
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_2;
+SELECT * FROM t1;
+f1
+10
+20
+30
+40
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_xa_simple.test
+++ b/mysql-test/suite/galera_sr/t/galera_xa_simple.test
@@ -112,3 +112,52 @@ SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 XA COMMIT 'test';
 
 DROP TABLE t1;
+
+
+#
+# Test D: XA transaction with streaming replication enabled, multiple
+# fragments before XA prepare.
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+# Explicitly set fragmentation before XA START
+SET SESSION wsrep_trx_fragment_size=1;
+
+XA START 'test';
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (20);
+INSERT INTO t1 VALUES (30);
+INSERT INTO t1 VALUES (40);
+# Four fragments should have been replicated
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+--echo expect empty set
+SELECT * FROM t1;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 4` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA END 'test';
+XA PREPARE 'test';
+
+--connection node_1a
+# Another fragment after XA PREPARE
+SELECT COUNT(*) `expect 5` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+XA COMMIT 'test';
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+
+--connection node_1
+# unset fragmentation
+SET SESSION wsrep_trx_fragment_size=0;
+DROP TABLE t1;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -10678,13 +10678,13 @@ bool wsrep_stmt_rollback_is_safe(THD* thd)
     binlog_cache_data * trx_cache = &cache_mngr->trx_cache;
     if (thd->wsrep_sr().fragments_certified() > 0 &&
         (trx_cache->get_prev_position() == MY_OFF_T_UNDEF ||
-         trx_cache->get_prev_position() < thd->wsrep_sr().bytes_certified()))
+         trx_cache->get_prev_position() < thd->wsrep_sr().log_position()))
     {
       WSREP_DEBUG("statement rollback is not safe for streaming replication"
                   " pre-stmt_pos: %llu, frag repl pos: %lu\n"
                   "Thread: %llu, SQL: %s",
                   trx_cache->get_prev_position(),
-                  thd->wsrep_sr().bytes_certified(),
+                  thd->wsrep_sr().log_position(),
                   thd->thread_id, thd->query());
        ret = false;
     }


### PR DESCRIPTION
`bytes_certified` includes data for XA events which are not included
in the binlog. For calculations of replicated data involving the
binlog, `log_position` must be used instead.