### PR TITLE
MDEV-17458 Unable to start galera node

### DIFF
--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -43,31 +43,16 @@ static long long wsrep_seqno = -1;
 /** The latest known WSREP XID UUID */
 static unsigned char wsrep_uuid[16];
 
-/** Update the WSREP XID information in rollback segment header.
+/** Write the WSREP XID information into rollback segment header.
 @param[in,out]	rseg_header	rollback segment header
 @param[in]	xid		WSREP XID
-@param[in,out]	mtr		mini-transaction */
-void
-trx_rseg_update_wsrep_checkpoint(
+@param[in,out]	mtr		mini transaction */
+static void
+trx_rseg_write_wsrep_checkpoint(
 	trx_rsegf_t*	rseg_header,
 	const XID*	xid,
 	mtr_t*		mtr)
 {
-	ut_ad(wsrep_is_wsrep_xid(xid));
-
-#ifdef UNIV_DEBUG
-	/* Check that seqno is monotonically increasing */
-	long long xid_seqno = wsrep_xid_seqno(xid);
-	const byte* xid_uuid = wsrep_xid_uuid(xid);
-
-	if (!memcmp(xid_uuid, wsrep_uuid, sizeof wsrep_uuid)) {
-		ut_ad(xid_seqno > wsrep_seqno);
-	} else {
-		memcpy(wsrep_uuid, xid_uuid, sizeof wsrep_uuid);
-	}
-	wsrep_seqno = xid_seqno;
-#endif /* UNIV_DEBUG */
-
 	mlog_write_ulint(TRX_RSEG_WSREP_XID_FORMAT + rseg_header,
 			 uint32_t(xid->formatID),
 			 MLOG_4BYTES, mtr);
@@ -85,6 +70,47 @@ trx_rseg_update_wsrep_checkpoint(
 			  XIDDATASIZE, mtr);
 }
 
+/** Update the WSREP XID information in rollback segment header.
+@param[in,out]	rseg_header	rollback segment header
+@param[in]	xid		WSREP XID
+@param[in,out]	mtr		mini-transaction */
+void
+trx_rseg_update_wsrep_checkpoint(
+	trx_rsegf_t*	rseg_header,
+	const XID*	xid,
+	mtr_t*		mtr)
+{
+	ut_ad(wsrep_is_wsrep_xid(xid));
+
+#ifdef UNIV_DEBUG
+	/* Check that seqno is monotonically increasing */
+	long long xid_seqno = wsrep_xid_seqno(xid);
+	const byte* xid_uuid = wsrep_xid_uuid(xid);
+
+	if (xid_seqno != -1
+	    && !memcmp(xid_uuid, wsrep_uuid, sizeof wsrep_uuid)) {
+		ut_ad(xid_seqno > wsrep_seqno);
+	} else {
+		memcpy(wsrep_uuid, xid_uuid, sizeof wsrep_uuid);
+	}
+	wsrep_seqno = xid_seqno;
+#endif /* UNIV_DEBUG */
+	trx_rseg_write_wsrep_checkpoint(rseg_header, xid, mtr);
+}
+
+/** Clear the WSREP XID information from rollback segment header.
+@param[in,out]	rseg_header	Rollback segment header
+@param[in,out]	mtr 		mini-transaction */
+static void
+trx_rseg_clear_wsrep_checkpoint(
+	trx_rsegf_t*	rseg_header,
+	mtr_t*		mtr)
+{
+	XID null_xid;
+	memset(&null_xid, 0, sizeof null_xid);
+	trx_rseg_write_wsrep_checkpoint(rseg_header, &null_xid, mtr);
+}
+
 /** Update WSREP checkpoint XID in first rollback segment header
 as part of wsrep_set_SE_checkpoint() when it is guaranteed that there
 are no wsrep transactions committing.
@@ -97,6 +123,13 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 	mtr_t	mtr;
 	mtr.start();
 
+	const byte* xid_uuid = wsrep_xid_uuid(xid);
+	/* We must make check against wsrep_uuid here, the
+	trx_rseg_update_wsrep_checkpoint() writes over wsrep_uuid with
+	xid contents in debug mode and the memcmp() will never give nonzero
+	result. */
+	const bool must_clear_rsegs = memcmp(wsrep_uuid, xid_uuid,
+					     sizeof wsrep_uuid);
 	const trx_rseg_t* rseg = trx_sys.rseg_array[0];
 
 	trx_rsegf_t* rseg_header = trx_rsegf_get(rseg->space, rseg->page_no,
@@ -107,10 +140,7 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 
 	trx_rseg_update_wsrep_checkpoint(rseg_header, xid, &mtr);
 
-	const byte* xid_uuid = wsrep_xid_uuid(xid);
-	if (memcmp(wsrep_uuid, xid_uuid, sizeof wsrep_uuid)) {
-		memcpy(wsrep_uuid, xid_uuid, sizeof wsrep_uuid);
-
+	if (must_clear_rsegs) {
 		/* Because the UUID part of the WSREP XID differed
 		from current_xid_uuid, the WSREP group UUID was
 		changed, and we must reset the XID in all rollback
@@ -118,10 +148,11 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 		for (ulint rseg_id = 1; rseg_id < TRX_SYS_N_RSEGS; ++rseg_id) {
 			if (const trx_rseg_t* rseg =
 			    trx_sys.rseg_array[rseg_id]) {
-				trx_rseg_update_wsrep_checkpoint(
+				trx_rseg_clear_wsrep_checkpoint(
 					trx_rsegf_get(rseg->space,
-						      rseg->page_no, &mtr),
-					xid, &mtr);
+						      rseg->page_no,
+						      &mtr),
+				        &mtr);
 			}
 		}
 	}


### PR DESCRIPTION
Bootstrapping a new cluster from a backup created from a MariaDB
version prior to 10.3.5, may result in error "SST position can't be
set in past" when attempting to join additional nodes.
The problem stems from the fact that when reading the wsrep position
from InnoDB, the position is looked up in two places:
the system header, where versions prior to 10.3.5 used to store
WSREP's position; and rollback segments, this is where newer versions
store the position.
When starting a new cluster, the starting seqno is 0 and a new cluster
UUID is generated. This is persisted in rollback segments, but the old
UUID and seqno are not cleared from the sys header.
Subsequently, when reading back the position,
`trx_rseg_read_wsrep_checkpoint` is going to return the maximum seqno
found in both system header and rollback segments. So in the case of a
newly bootstrapped cluster, it's always going to return the old
cluster information.
The fix consists of changing `trx_rseg_read_wsrep_checkpoint` so that
only rollback segments are looked up. On startup, the sys header
position is read, and if present, it is copied to rollback segments
unless a newer position is already present in the rollback segments.
Finally the sys header position is cleared.