### PR TITLE
MDEV-xxxxx Fix wsrep crash with change user command

### DIFF
--- a/mysql-test/suite/galera/r/galera_change_user.result
+++ b/mysql-test/suite/galera/r/galera_change_user.result
@@ -1,0 +1,8 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE USER user1;
+connect node_1a, 127.0.0.1, root, , test, $MYPORT_NODE_1;
+disconnect node_1a;
+connection node_1;
+DROP USER user1;

--- a/mysql-test/suite/galera/t/galera_change_user.test
+++ b/mysql-test/suite/galera/t/galera_change_user.test
@@ -1,0 +1,18 @@
+#
+# Check that change user works with Galera
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+CREATE USER user1;
+
+--connect node_1a, 127.0.0.1, root, , test, $MYPORT_NODE_1
+change_user 'user1';
+reset_connection;
+--disconnect node_1a
+
+--connection node_1
+DROP USER user1;
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1660,8 +1660,16 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
   case COM_RESET_CONNECTION:
   {
     thd->status_var.com_other++;
+#ifdef WITH_WSREP
+    wsrep_after_command_ignore_result(thd);
+    wsrep_close(thd);
+#endif /* WITH_WSREP */
     thd->change_user();
     thd->clear_error();                         // if errors from rollback
+#ifdef WITH_WSREP
+    wsrep_open(thd);
+    wsrep_before_command(thd);
+#endif /* WITH_WSREP */
     /* Restore original charset from client authentication packet.*/
     if(thd->org_charset)
       thd->update_charset(thd->org_charset,thd->org_charset,thd->org_charset);
@@ -1673,7 +1681,15 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
     int auth_rc;
     status_var_increment(thd->status_var.com_other);
 
+#ifdef WITH_WSREP
+    wsrep_after_command_ignore_result(thd);
+    wsrep_close(thd);
+#endif /* WITH_WSREP */
     thd->change_user();
+#ifdef WITH_WSREP
+    wsrep_open(thd);
+    wsrep_before_command(thd);
+#endif /* WITH_WSREP */
     thd->clear_error();                         // if errors from rollback
 
     /* acl_authenticate() takes the data from net->read_pos */


### PR DESCRIPTION
Client initiated change user or reset connection command causes
THD::cleanup() to be called in the middle of command handling.
This causes wsrep client_state sanity checks to fail.

As a fix, temporarily close wsrep client_state before change user
and restore the state after change user is completed.

This commit also updates wsrep-lib to version which removes
exception usage in wsrep client_state sanity checks.