### PR TITLE
MDEV-17047 Update wsrep-lib in 10.4

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -509,6 +509,14 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta& ws_meta,
   DBUG_RETURN(ret);
 }
 
+int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta& ws_meta,
+                                           const wsrep::const_buffer& data,
+                                           wsrep::mutable_buffer& err)
+{
+  DBUG_ENTER("Wsrep_applier_service::apply_nbo_begin");
+  DBUG_RETURN(0);
+}
+
 void Wsrep_applier_service::after_apply()
 {
   DBUG_ENTER("Wsrep_applier_service::after_apply");

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -86,6 +86,8 @@ public:
   ~Wsrep_applier_service();
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&,
                       wsrep::mutable_buffer&);
+  int apply_nbo_begin(const wsrep::ws_meta&, const wsrep::const_buffer& data,
+                      wsrep::mutable_buffer& err);
   void after_apply();
   bool is_replaying() const { return false; }
   bool check_exit_status() const;
@@ -98,6 +100,12 @@ public:
   ~Wsrep_replayer_service();
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&,
                       wsrep::mutable_buffer&);
+  int apply_nbo_begin(const wsrep::ws_meta&, const wsrep::const_buffer& data,
+                      wsrep::mutable_buffer& err)
+  {
+    DBUG_ASSERT(0); /* DDL should never cause replaying */
+    return 0;
+  }
   void after_apply() { }
   bool is_replaying() const { return true; }
   void replay_status(enum wsrep::provider::status status)

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1885,9 +1885,7 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
 
   wsrep::client_state& cs(thd->wsrep_cs());
   int ret= cs.enter_toi_local(key_array,
-                              wsrep::const_buffer(buff.ptr, buff.len),
-                              wsrep::provider::flag::start_transaction |
-                              wsrep::provider::flag::commit);
+                              wsrep::const_buffer(buff.ptr, buff.len));
 
   if (ret)
   {


### PR DESCRIPTION
Update wsrep-lib in order to adapt to upcoming non-blocking DDL
changes in 10.5.