### PR TITLE
MENT-432 BF lock wait long during IST

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -998,7 +998,7 @@ lock_tables(MYSQL *connection)
 
 	if (have_galera_enabled) {
 		xb_mysql_query(connection,
-				"SET SESSION wsrep_causal_reads=0", false);
+				"SET SESSION wsrep_sync_wait=0", false);
 	}
 
 	xb_mysql_query(connection, "FLUSH TABLES WITH READ LOCK", false);

--- a/extra/mariabackup/wsrep.cc
+++ b/extra/mariabackup/wsrep.cc
@@ -54,6 +54,9 @@ permission notice:
 /*! Name of file where Galera info is stored on recovery */
 #define XB_GALERA_INFO_FILENAME "xtrabackup_galera_info"
 
+/* backup copy of galera info file as sent by donor */
+#define XB_GALERA_INFO_FILENAME_SST "xtrabackup_galera_info_SST"
+
 /***********************************************************************
 Store Galera checkpoint info in the 'xtrabackup_galera_info' file, if that
 information is present in the trx system header. Otherwise, do nothing. */
@@ -67,19 +70,33 @@ xb_write_galera_info(bool incremental_prepare)
 	long long	seqno;
 	MY_STAT		statinfo;
 
-	/* Do not overwrite existing an existing file to be compatible with
-	servers with older server versions */
-	if (!incremental_prepare &&
-		my_stat(XB_GALERA_INFO_FILENAME, &statinfo, MYF(0)) != NULL) {
+	xid.null();
 
+	/* try to read last wsrep XID from innodb rsegs, we will use it
+	   instead of galera info file received from donor
+	*/
+	if (!trx_rseg_read_wsrep_checkpoint(xid)) {
+		/* no worries yet, SST may have brought in galera info file
+		   from some old MariaDB version, which does not support
+		   wsrep XID storing in innodb rsegs
+		*/
 		return;
 	}
 
-	xid.null();
+	/* if SST brought in galera info file, copy it as *_SST file
+	   this will not be used, saved just for future reference
+	*/
+	if (my_stat(XB_GALERA_INFO_FILENAME, &statinfo, MYF(0)) != NULL) {
+		FILE* fp_in  = fopen(XB_GALERA_INFO_FILENAME, "r");
+		FILE* fp_out = fopen(XB_GALERA_INFO_FILENAME_SST, "w");
 
-	if (!trx_rseg_read_wsrep_checkpoint(xid)) {
-
-		return;
+		char buf[BUFSIZ];
+		size_t size;
+		while ((size = fread(buf, 1, BUFSIZ, fp_in))) {
+			fwrite(buf, 1, size, fp_out);
+		}
+		fclose(fp_out);
+		fclose(fp_in);
 	}
 
 	wsrep_uuid_t uuid;


### PR DESCRIPTION
mariabackup was using wsrep variable 'wsrep_causal_reads', which is deprecated and replaced by 'wsrep_sync_wait'. Fixed to use wsrep_sync_wait=0, to prevent any cluster replication waiting during mariabackup operation.

xb_write_galera_info() used to bail out unconditionally, if donor has sent xtrabackup_galera_info sile. This was supposed to support old mariadb versions operating as donor, and which would not have rseg based storage for wsrep XID.

However, 10.3 and later donors do send xtrabackup_galera_info, and becasue of this innodb rseg was never scanned for wsrep XID. This is a problem because innodb rseg, in 10.3 ES would often contain much newer galera GTID. The patch will try of innodb rseg has a valid wsrep XID, and will use it. If donor was of old version, the xtrabackup_galera_info file would be used instead.

The original xtrabackup_galera_info file, as reeived from donor, is copied to xtrabackup_galera_info_SST, just for troubleshooting purpose.