### PR TITLE
MENT-432 BF lock wait long during IST

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -57,6 +57,9 @@
 #include "wsrep.h"
 #include "wsrep_xid.h"
 
+/* for updating local_seqno if node is doing xarecovery after SST donation */
+extern wsrep_seqno_t local_seqno;
+
 /*
   While we have legacy_db_type, we have this array to
   check for dups and to find handlerton from legacy_db_type.
@@ -1981,7 +1984,12 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
       if (WSREP_ON)
       {
         wsrep_limit= wsrep_order_and_check_continuity(info->list, got);
-      }
+        if (wsrep_limit > 0) {
+          WSREP_DEBUG("updating local_seqno %llu -> %llu",
+                      local_seqno, wsrep_limit);
+          local_seqno = wsrep_limit;
+        }
+       }
 #endif /* WITH_WSREP */
 
       for (int i=0; i < got; i ++)
@@ -6744,6 +6752,14 @@ int ha_abort_transaction(THD *bf_thd, THD *victim_thd, my_bool signal)
 
   DBUG_RETURN(0);
 }
+
+#ifdef WITH_WSREP
+void wsrep_wait_until_innodb_initialized()
+{
+  handlerton *hton= installed_htons[DB_TYPE_INNODB];
+  hton->wait_until_initialized(hton);
+}
+#endif /* WITH_WSREP */
 
 void ha_fake_trx_id(THD *thd)
 {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1476,6 +1476,9 @@ struct handlerton
    int (*set_checkpoint)(handlerton *hton, const XID* xid);
    int (*get_checkpoint)(handlerton *hton, XID* xid);
    void (*fake_trx_id)(handlerton *hton, THD *thd);
+#ifdef WITH_WSREP
+  void (*wait_until_initialized)(handlerton *hton);
+#endif /* WITH_WSREP */
    /*
      Optional clauses in the CREATE/ALTER TABLE
    */
@@ -4840,9 +4843,10 @@ int ha_release_savepoint(THD *thd, SAVEPOINT *sv);
 #ifdef WITH_WSREP
 int ha_abort_transaction(THD *bf_thd, THD *victim_thd, my_bool signal);
 void ha_fake_trx_id(THD *thd);
-#else
+void wsrep_wait_until_innodb_initialized();
+ #else
 inline void ha_fake_trx_id(THD *thd) { }
-#endif
+#endif /* WITH_WSREP */
 
 /* these are called by storage engines */
 void trans_register_ha(THD *thd, bool all, handlerton *ht);

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -365,6 +365,7 @@ bool wsrep_sst_received (wsrep_t*            const wsrep,
 // Let applier threads to continue
 bool wsrep_sst_continue ()
 {
+  wsrep_wait_until_innodb_initialized();
   if (sst_needed)
   {
     WSREP_INFO("Signalling provider to continue.");

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -159,6 +159,8 @@ static int
 wsrep_abort_transaction(handlerton* hton, THD *bf_thd, THD *victim_thd,
 			my_bool signal);
 static void
+wsrep_wait_until_initialized(handlerton* hton);
+static void
 wsrep_fake_trx_id(handlerton* hton, THD *thd);
 static int innobase_wsrep_set_checkpoint(handlerton* hton, const XID* xid);
 static int innobase_wsrep_get_checkpoint(handlerton* hton, XID* xid);
@@ -4165,7 +4167,8 @@ static int innodb_init(void* p)
 	innobase_hton->set_checkpoint=innobase_wsrep_set_checkpoint;
 	innobase_hton->get_checkpoint=innobase_wsrep_get_checkpoint;
 	innobase_hton->fake_trx_id=wsrep_fake_trx_id;
-#endif /* WITH_WSREP */
+	innobase_hton->wait_until_initialized=wsrep_wait_until_initialized;
+ #endif /* WITH_WSREP */
 
 	innobase_hton->tablefile_extensions = ha_innobase_exts;
 	innobase_hton->table_options = innodb_table_option_list;
@@ -19052,6 +19055,25 @@ wsrep_innobase_kill_one_trx(
 	}
 
 	DBUG_RETURN(0);
+}
+
+static
+void
+wsrep_wait_until_initialized(
+/*====================*/
+       handlerton*)
+{
+	extern bool trx_rollback_is_active;
+	DBUG_ENTER("wsrep_innodb_wait_untill_initialized");
+
+	WSREP_DEBUG("waiitng until innodb is initialized %d",
+		   trx_rollback_is_active);
+	while (trx_rollback_is_active) {
+		WSREP_DEBUG("innodb rollbacker still active");
+		sleep(1);
+	}
+	WSREP_DEBUG("innodb is now initialized %d", trx_rollback_is_active);
+	DBUG_VOID_RETURN;
 }
 
 static


### PR DESCRIPTION
MENT-432 has showed that in ES 10.3 and later ES releases, the innodb background rollbacker thread, launched at recover phase, may conflict with wsrep applier threads performing IST applying after mariabackup SST.
This conflict may result applier threads starving and throwing "BF lock wait long" warnings in error log.
Reason for background rollbacker and wsrep applier conflict is not completely understood, epecialy why similar conflict does not happen in CS version, remains a mystery.

The fix in this patch addes new handlerton method 'wait_until_initialized', which will block the caller until the SE has completed all such background tasks, which may conflict with replication.
Innodb handler implements this method as "sleep wait loop", monitoring the innodb background rollbacker activity state. This part should still be refactored to not use sleep(), but rather a mutex and cond variable signaling.
However, current implementation may be tested and should enable the related mtr test to pass.