### PR TITLE
Implement WSREP_LOG as a function

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -213,6 +213,45 @@ wsp::Config_state wsrep_config_state;
 // if there was no state gap on receiving first view event.
 static my_bool   wsrep_startup = TRUE;
 
+void WSREP_LOG(void (*fun)(const char* fmt, ...), const char* fmt, ...)
+{
+  /* Allocate short buffer from stack. If the vsnprintf() return value
+     indicates that the message was truncated, a new buffer will be allocated
+     dynamically and the message will be reprinted. */
+  char msg[128] = {'\0'};
+  va_list arglist;
+  va_start(arglist, fmt);
+  int n= vsnprintf(msg, sizeof(msg) - 1, fmt, arglist);
+  va_end(arglist);
+  if (n < 0)
+  {
+    sql_print_warning("WSREP: Printing message failed");
+  }
+  else if (n < (int)sizeof(msg))
+  {
+    fun("WSREP: %s", msg);
+  }
+  else
+  {
+    size_t dynbuf_size= std::max(n, 4096);
+    char* dynbuf= (char*) my_malloc(dynbuf_size, MYF(0));
+    if (dynbuf)
+    {
+      va_start(arglist, fmt);
+      (void)vsnprintf(&dynbuf[0], dynbuf_size - 1, fmt, arglist);
+      va_end(arglist);
+      dynbuf[dynbuf_size - 1] = '\0';
+      fun("WSREP: %s", &dynbuf[0]);
+      my_free(dynbuf);
+    }
+    else
+    {
+      /* Memory allocation for vector failed, print truncated message. */
+      fun("WSREP: %s", msg);
+    }
+  }
+}
+
 
 static void wsrep_log_cb(wsrep_log_level_t level, const char *msg) {
   switch (level) {

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -200,13 +200,10 @@ extern wsrep_seqno_t wsrep_locked_seqno;
   ((wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC)   \
     ? wsrep_forced_binlog_format : (ulong)(my_format))
 
-// prefix all messages with "WSREP"
-#define WSREP_LOG(fun, ...)                                       \
-    do {                                                          \
-        char msg[1024] = {'\0'};                                  \
-        snprintf(msg, sizeof(msg) - 1, ## __VA_ARGS__);           \
-        fun("WSREP: %s", msg);                                    \
-    } while(0)
+/* A wrapper function for MySQL log functions. The call will prefix
+   the log message with WSREP and forwards the result buffer to
+   MySQL log function specified in fun. */
+void WSREP_LOG(void (*fun)(const char* fmt, ...), const char* fmt, ...);
 
 #define WSREP_LOG_CONFLICT_THD(thd, role)                                      \
     WSREP_LOG(sql_print_information, 	                                       \


### PR DESCRIPTION
- Made WSREP_LOG a function and moved the body out of header.
- Reduced the stack allocated buffer size and implemented
  reprint into dynamically allocated buffer if stack buffer is not
  large enough to hold the message.