### PR TITLE
MDEV-21025 Server crashes on START TRANSACTION after INSERT IGNORE

### DIFF
--- a/mysql-test/suite/galera/r/mdev_21025.result
+++ b/mysql-test/suite/galera/r/mdev_21025.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES (1);
+START TRANSACTION;
+INSERT IGNORE INTO t1 (f1) VALUES (1);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
+START TRANSACTION;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/mdev_21025.test
+++ b/mysql-test/suite/galera/t/mdev_21025.test
@@ -1,0 +1,22 @@
+#
+# MDEV-21205
+#
+# Start transaction after INSERT IGNORE which had no effect and
+# kept the transaction open caused an assertion on the following
+# START TRANSACTION because the empty transaction was not properly
+# terminated.
+#
+
+--source include/galera_cluster.inc
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES (1);
+
+START TRANSACTION;
+# This INSERT succeeds with duplicate key warning due to IGNORE clause
+# and keeps the transaction open. The following START TRANSACTION causes
+# an assertion if the bug is present.
+INSERT IGNORE INTO t1 (f1) VALUES (1);
+START TRANSACTION;
+
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1705,7 +1705,8 @@ end:
     thd->mdl_context.release_lock(mdl_request.ticket);
   }
 #ifdef WITH_WSREP
-  if (wsrep_is_active(thd) && is_real_trans && !error && (rw_ha_count == 0) &&
+  if (wsrep_is_active(thd) && is_real_trans && !error &&
+      (rw_ha_count == 0 || all) &&
       wsrep_not_committed(thd))
   {
     wsrep_commit_empty(thd, all);


### PR DESCRIPTION
If a transaction had no effect due to INSERT IGNORE and a new
transaction was started with START TRANSACTION without committing
the previous one, the server crashed on assertion when starting
a new wsrep transaction.

As a fix, make sure that any open wsrep transaction is terminated
in trans_begin() before starting a new one.