### PR TITLE
MDEV-22203 Optimizing WSREP_ON macro

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1874,7 +1874,7 @@ extern "C" void unireg_abort(int exit_code)
   disable_log_notes= 1;
 
 #ifdef WITH_WSREP
-  if (WSREP_ON &&
+  if (WSREP_DEFINED &&
       Wsrep_server_state::is_inited() &&
       Wsrep_server_state::instance().state() != wsrep::server_state::s_disconnected)
   {
@@ -1889,7 +1889,7 @@ extern "C" void unireg_abort(int exit_code)
     sleep(1); /* so give some time to exit for those which can */
     WSREP_INFO("Some threads may fail to exit.");
   }
-  if (WSREP_ON)
+  if (WSREP_DEFINED)
   {
     /* In bootstrap mode we deinitialize wsrep here. */
     if (opt_bootstrap || wsrep_recovery)
@@ -5005,7 +5005,7 @@ static int init_server_components()
   xid_cache_init();
 
   /* need to configure logging before initializing storage engines */
-  if (!opt_bin_log_used && !WSREP_ON)
+  if (!opt_bin_log_used && !WSREP_DEFINED)
   {
     if (opt_log_slave_updates)
       sql_print_warning("You need to use --log-bin to make "
@@ -5113,7 +5113,7 @@ static int init_server_components()
 #ifdef WITH_WSREP
   if (wsrep_init_server()) unireg_abort(1);
 
-  if (WSREP_ON && !wsrep_recovery && !opt_abort)
+  if (WSREP_DEFINED && !wsrep_recovery && !opt_abort)
   {
     if (opt_bootstrap) // bootsrap option given - disable wsrep functionality
     {
@@ -5355,7 +5355,7 @@ static int init_server_components()
   if (wsrep_before_SE())
     wsrep_plugins_post_init();
 
-  if (WSREP_ON && !opt_bin_log)
+  if (WSREP_DEFINED && !opt_bin_log)
   {
     wsrep_emulate_bin_log= 1;
   }
@@ -5718,7 +5718,7 @@ int mysqld_main(int argc, char **argv)
       set_user(mysqld_user, user_info);
   }
 
-  if (WSREP_ON && wsrep_check_opts()) unireg_abort(1);
+  if (WSREP_DEFINED && wsrep_check_opts()) unireg_abort(1);
 
   /* 
    The subsequent calls may take a long time : e.g. innodb log read.
@@ -5746,7 +5746,7 @@ int mysqld_main(int argc, char **argv)
   if (wsrep_recovery)
   {
     select_thread_in_use= 0;
-    if (WSREP_ON)
+    if (WSREP_DEFINED)
       wsrep_recover();
     else
       sql_print_information("WSREP: disabled, skipping position recovery");
@@ -5793,7 +5793,7 @@ int mysqld_main(int argc, char **argv)
   if (Events::init((THD*) 0, opt_noacl || opt_bootstrap))
     unireg_abort(1);
 
-  if (WSREP_ON)
+  if (WSREP_DEFINED)
   {
     if (opt_bootstrap)
     {
@@ -8871,7 +8871,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr)
     global_system_variables.binlog_format= BINLOG_FORMAT_ROW;
   }
 
-  if (!opt_bootstrap && WSREP_PROVIDER_EXISTS && WSREP_ON &&
+  if (!opt_bootstrap && WSREP_DEFINED &&
       global_system_variables.binlog_format != BINLOG_FORMAT_ROW)
   {
 
@@ -9334,7 +9334,7 @@ void refresh_status(THD *thd)
   /* Reset some global variables */
   reset_status_vars();
 #ifdef WITH_WSREP
-  if (WSREP_ON)
+  if (WSREP_DEFINED)
   {
     Wsrep_server_state::instance().provider().reset_status();
   }

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -84,6 +84,8 @@ const char *wsrep_data_home_dir;
 const char *wsrep_dbug_option;
 const char *wsrep_notify_cmd;
 
+my_bool wsrep_provider_set;
+
 ulong   wsrep_debug;                            // Debug level logging
 my_bool wsrep_convert_LOCK_to_trx;              // Convert locking sessions to trx
 my_bool wsrep_auto_increment_control;           // Control auto increment variables
@@ -693,7 +695,7 @@ void wsrep_init_globals()
 {
   wsrep_init_sidno(Wsrep_server_state::instance().connected_gtid().id());
   wsrep_init_schema();
-  if (WSREP_ON)
+  if (WSREP_DEFINED)
   {
     Wsrep_server_state::instance().initialized();
   }
@@ -708,12 +710,12 @@ void wsrep_deinit_server()
 int wsrep_init()
 {
   assert(wsrep_provider);
+  wsrep_provider_set = false;
 
   wsrep_init_position();
   wsrep_sst_auth_init();
 
-  if (strlen(wsrep_provider)== 0 ||
-      !strcmp(wsrep_provider, WSREP_NONE))
+  if (!WSREP_PROVIDER_EXISTS)
   {
     // enable normal operation in case no provider is specified
     global_system_variables.wsrep_on= 0;
@@ -768,6 +770,7 @@ int wsrep_init()
   WSREP_DEBUG("SR storage init for: %s",
               (wsrep_SR_store_type == WSREP_SR_STORE_TABLE) ? "table" : "void");
 
+  wsrep_provider_set = true;
   return 0;
 }
 
@@ -830,7 +833,7 @@ void wsrep_init_startup (bool sst_first)
     wsrep_plugins_pre_init();
 
   /* Skip replication start if dummy wsrep provider is loaded */
-  if (!strcmp(wsrep_provider, WSREP_NONE)) return;
+  if (!WSREP_DEFINED) return;
 
   /* Skip replication start if no cluster address */
   if (!wsrep_cluster_address || wsrep_cluster_address[0] == 0) return;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -213,10 +213,20 @@ extern void wsrep_prepend_PATH (const char* path);
 
 /* Other global variables */
 extern wsrep_seqno_t wsrep_locked_seqno;
-#define WSREP_ON                         \
-  ((global_system_variables.wsrep_on) && \
-   wsrep_provider                     && \
-   strcmp(wsrep_provider, WSREP_NONE))
+
+#define WSREP_PROVIDER_EXISTS						\
+  (wsrep_provider && strncasecmp(wsrep_provider, WSREP_NONE, FN_REFLEN))
+
+/* this macro is meant to be used during server initialization to see if node is
+   supposed to be in cluster */
+#define WSREP_DEFINED                    \
+  (global_system_variables.wsrep_on && WSREP_PROVIDER_EXISTS)
+
+#define WSREP_ON						\
+  (global_system_variables.wsrep_on && wsrep_provider_set)
+
+
+extern my_bool wsrep_provider_set;
 
 /* use xxxxxx_NNULL macros when thd pointer is guaranteed to be non-null to
  * avoid compiler warnings (GCC 6 and later) */
@@ -280,9 +290,6 @@ extern wsrep_seqno_t wsrep_locked_seqno;
     if (victim_thd) WSREP_LOG_CONFLICT_THD(victim_thd, "Victim thread"); \
     WSREP_LOG(sql_print_information, "context: %s:%d", __FILE__, __LINE__); \
   }
-
-#define WSREP_PROVIDER_EXISTS                                                  \
-  (wsrep_provider && strncasecmp(wsrep_provider, WSREP_NONE, FN_REFLEN))
 
 #define WSREP_QUERY(thd) (thd->query())
 

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -121,7 +121,7 @@ bool wsrep_create_appliers(long threads, bool mutex_protected)
   /*  Dont' start slave threads if wsrep-provider or wsrep-cluster-address
       is not set.
   */
-  if (!WSREP_PROVIDER_EXISTS)
+  if (!WSREP_DEFINED)
   {
     return false;
   }


### PR DESCRIPTION
This pull request fixes both MDEV-22203 and MDEV-7962
Old implementation of WSREP_ON macro contained strcmp() call to check
if magic provider name "none" was configured to skip defining a valid
replication provider.

The fix in this pull request intoroduces new macro WSREP_DEFINED, to
check if valid provider name is specified and wsrep_on variable is set.
This is actually same behavior as the old WSREP_ON macro had.

A new global boolean variable wsrep_provider_set is now used to follow
the wsrep_provider variable changes. wsrep_provider_set will be true if
wsrep_provider has a proper library name.

WSREP_ON is modified to use the wsrep_provider_set boolean, and thus avoiding
the strcmp() call.

WSREP_DEFINED macro is used only in server initialization phase, where
wsrep_provider_set may not yet have been established. WSREP_ON is used all
over the code base, and should now have lower impact on query execution perfromance.

There is no separate mtr test for this pull request. For qualifying: no regressions
should happen with mtr testing and performance testing/profiling should show
somewhat better results and wsrep_on() function should have lower ranking in performance
bottleneck ranking