### PR TITLE
MDEV-22425: Galera test failure on galera.MDEV-10715

### DIFF
--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -297,18 +297,10 @@ extern "C" int wsrep_thd_append_key(THD *thd,
 extern "C" void wsrep_commit_ordered(THD *thd)
 {
   if (wsrep_is_active(thd) &&
-      (thd->wsrep_trx().state() == wsrep::transaction::s_committing ||
-       thd->wsrep_trx().state() == wsrep::transaction::s_ordered_commit))
+      thd->wsrep_trx().state() == wsrep::transaction::s_committing &&
+      !wsrep_commit_will_write_binlog(thd))
   {
-    wsrep_gtid_server.signal_waiters(thd->wsrep_current_gtid_seqno, false);
-    if (wsrep_thd_is_local(thd))
-    {
-      thd->wsrep_last_written_gtid_seqno= thd->wsrep_current_gtid_seqno;
-    }
-    if (!wsrep_commit_will_write_binlog(thd))
-    {
-      thd->wsrep_cs().ordered_commit();
-    }
+    thd->wsrep_cs().ordered_commit();
   }
 }
 


### PR DESCRIPTION
Update of thread `wsrep_last_written_gtid_seqno` variable and signaling
possible GTID waiters should be done in `wsrep_after_commit`.