### PR TITLE
MDEV-22452: Missing call to wsrep_commit_ordered in trx_t::commit

### DIFF
--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -444,6 +444,9 @@ void trx_free(trx_t*& trx)
 	trx->mysql_thd = 0;
 	trx->mysql_log_file_name = 0;
 
+#ifdef WITH_WSREP
+	trx->wsrep = false;
+#endif /* WITH_WSREP */
 	// FIXME: We need to avoid this heap free/alloc for each commit.
 	if (trx->autoinc_locks != NULL) {
 		ut_ad(ib_vector_is_empty(trx->autoinc_locks));

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1504,6 +1504,14 @@ inline void trx_t::commit_in_memory(const mtr_t *mtr)
   DBUG_LOG("trx", "Commit in memory: " << this);
   state= TRX_STATE_NOT_STARTED;
 
+#ifdef WITH_WSREP
+  /* Serialization history has been written and the transaction is
+  committed in memory, which makes this commit ordered. Release commit
+  order critical section. */
+  if (mtr && is_wsrep())
+    wsrep_commit_ordered(mysql_thd);
+#endif /* WITH_WSREP */
+
   assert_trx_is_free(this);
   trx_init(this);
   trx_mutex_exit(this);
@@ -1581,13 +1589,6 @@ void trx_t::commit()
     local_mtr.start();
   }
   commit_low(mtr);
-#ifdef WITH_WSREP
-  /* Serialization history has been written and the transaction is
-  committed in memory, which makes this commit ordered. Release commit
-  order critical section. */
-  if (mtr && is_wsrep())
-    wsrep_commit_ordered(mysql_thd);
-#endif /* WITH_WSREP */
 }
 
 /****************************************************************//**


### PR DESCRIPTION
Calling wsrep_commit_ordered require that trx->wsrep is enabled.
Move this call to be executed before `trx_init` in `trx_t:commit_in_memory`
because `trx_init` will set explicitly trx->wsrep to false.