### PR TITLE
MDEV-22505: Test failure on galera.galera_bf_abort_shutdown

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2673,6 +2673,7 @@ innobase_trx_init(
 	trx->check_unique_secondary = !thd_test_options(
 		thd, OPTION_RELAXED_UNIQUE_CHECKS);
 #ifdef WITH_WSREP
+	trx->lock.was_chosen_as_wsrep_victim = false;
 	trx->wsrep = wsrep_on(thd);
 #endif
 

--- a/storage/innobase/trx/trx0roll.cc
+++ b/storage/innobase/trx/trx0roll.cc
@@ -452,9 +452,7 @@ trx_rollback_to_savepoint_for_mysql_low(
 	trx_mark_sql_stat_end(trx);
 
 	trx->op_info = "";
-#ifdef WITH_WSREP
-	trx->lock.was_chosen_as_wsrep_victim = false;
-#endif
+
 	return(err);
 }
 


### PR DESCRIPTION
If transaction was BF aborted `trx->lock.was_chosen_as_wsrep_victim` will be set
and returned to trx pool. After we reuse same transaction, we need to invalidate value.