### PR TITLE
MDEV-22616 CHECK TABLE fails with wsrep_trx_fragment_size > 0

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-22616.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-22616.result
@@ -1,0 +1,13 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_size = 1;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/MDEV-22616.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-22616.test
@@ -1,0 +1,18 @@
+#
+# MDEV-22616
+# 
+# CHECK TABLE fails with wsrep_trx_fragment_size > 0
+#
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_size = 1;
+CHECK TABLE t1;
+
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+
+CHECK TABLE t1;
+
+DROP TABLE t1;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5758,7 +5758,9 @@ int THD::decide_logging_format(TABLE_LIST *tables)
     binlog by filtering rules.
   */
 #ifdef WITH_WSREP
-  if (WSREP_CLIENT_NNULL(this) && wsrep_thd_is_local(this) &&
+  if (WSREP_CLIENT_NNULL(this) &&
+      wsrep_thd_is_local(this) &&
+      wsrep_is_active(this) &&
       variables.wsrep_trx_fragment_size > 0)
   {
     if (!is_current_stmt_binlog_format_row())


### PR DESCRIPTION
Executing CHECK TABLE  with streaming replication enabled reports
error "Streaming replication not supported with
binlog_format=STATEMENT".
Administrative commands such as CHECK TABLE, are not replicated and
temporarily set binlog format to statement.
To avoid the problem, report the error only for active transactions
for which streaming replication is enabled.