### PR TITLE
MDEV-22666 galera.MW-328A hang

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_kill.result
+++ b/mysql-test/suite/galera/r/galera_bf_kill.result
@@ -70,3 +70,20 @@ a	b
 2	1
 disconnect node_2a;
 drop table t1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2a;
+CREATE TABLE t1 (i int primary key);
+SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
+SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
+SET DEBUG_SYNC='RESET';
+connection node_2a;
+connection node_2;
+select * from t1;
+i
+1
+disconnect node_2a;
+connection node_2;
+drop table t1;

--- a/mysql-test/suite/galera/t/MW-328-footer.inc
+++ b/mysql-test/suite/galera/t/MW-328-footer.inc
@@ -4,6 +4,9 @@
 
 --connection node_1
 --disable_query_log
+
+# kill may fail, if victim is in replicating phase
+--error 0, ER_KILL_DENIED_ERROR
 --eval KILL CONNECTION $sp_connection_id
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/galera_bf_kill.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill.test
@@ -139,5 +139,49 @@ select * from t1;
 
 drop table t1;
 
+#
+# Test case 7:
+# run a transaction in node 2, and set a sync point to pause the transaction
+# in commit phase.
+# Through another connection to node 2, kill the committing transaction by
+# KILL QUERY command
+#
 
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--let $connection_id = `SELECT CONNECTION_ID()`
+
+CREATE TABLE t1 (i int primary key);
+
+# Set up sync point
+SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
+
+# Send insert which will block in the sync point above
+--send INSERT INTO t1 VALUES (1)
+
+--connection node_2
+SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
+
+--disable_query_log
+--disable_result_log
+# victim has passed the point of no return, kill is not possible anymore
+--error ER_KILL_DENIED_ERROR
+--eval KILL QUERY $connection_id
+--enable_result_log
+--enable_query_log
+
+SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
+SET DEBUG_SYNC='RESET';
+--connection node_2a
+--error 0,1213
+--reap
+
+--connection node_2
+# victim was able to complete the INSERT
+select * from t1;
+
+--disconnect node_2a
+
+--connection node_2
+drop table t1;
 

--- a/mysql-test/suite/galera_sr/t/galera_sr_kill_query.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_kill_query.test
@@ -24,6 +24,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --echo Killing query ...
 --disable_query_log
+--error 0, ER_KILL_DENIED_ERROR
 --eval KILL QUERY $connection_id
 --enable_query_log
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -299,6 +299,7 @@ extern "C" void wsrep_commit_ordered(THD *thd)
       thd->wsrep_trx().state() == wsrep::transaction::s_committing &&
       !wsrep_commit_will_write_binlog(thd))
   {
+    DEBUG_SYNC(thd, "before_wsrep_ordered_commit");
     thd->wsrep_cs().ordered_commit();
   }
 }


### PR DESCRIPTION
The hang can happen between a lock connection issuing KILL CONNECTION for a victim,
which is in committing phase. There is two resource deadlock killer is holding victim's
LOCK_thd_data and requires trx mutex for the victim. The victim, otoh, holds his own trx
mutex, but requires LOCK_thd_data in wsrep_commit_ordered().
Hence a classic two thread deadlock happens.

The fix, in this commit, check in sql_kill phase, if the victim is in committing phase,
and skips calling THD::awake() wchich would dive into innodb trying to acquire trx mutex.
Instead, we only set THD:killed of the victim, which should observe the killed status
after commit is complete.

MW-328 test has been changed to allow few errors from KILL CONNECTION. This part should be
refactored to see if KIL CONNECTION can be allowed to always succeed and gurantee effective
kill, in all cases.