### PR TITLE
MDEV-21910 Deadlock between BF abort and manual KILL command

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -84,6 +84,7 @@ extern struct wsrep_service_st {
   my_bool                     (*wsrep_get_debug_func)();
   void                        (*wsrep_commit_ordered_func)(MYSQL_THD thd);
   my_bool                     (*wsrep_thd_is_applying_func)(const MYSQL_THD thd);
+  bool                        (*wsrep_thd_set_wsrep_killed_func)(MYSQL_THD thd);
 } *wsrep_service;
 
 #define MYSQL_SERVICE_WSREP_INCLUDED
@@ -124,6 +125,7 @@ extern struct wsrep_service_st {
 #define wsrep_get_debug() wsrep_service->wsrep_get_debug_func()
 #define wsrep_commit_ordered(T) wsrep_service->wsrep_commit_ordered_func(T)
 #define wsrep_thd_is_applying(T) wsrep_service->wsrep_thd_is_applying_func(T)
+#define wsrep_thd_set_wsrep_killed(T) wsrep_service->wsrep_thd_set_wsrep_killed_func(T)
 
 #else
 
@@ -176,6 +178,8 @@ extern "C" my_bool wsrep_thd_is_local(const MYSQL_THD thd);
 /* Return true if thd is in high priority mode */
 /* todo: rename to is_high_priority() */
 extern "C" my_bool wsrep_thd_is_applying(const MYSQL_THD thd);
+/* set wsrep_killed flag for the target THD */
+extern "C" bool wsrep_thd_set_wsrep_killed(MYSQL_THD thd);
 /* Return true if thd is in TOI mode */
 extern "C" my_bool wsrep_thd_is_toi(const MYSQL_THD thd);
 /* Return true if thd is in replicating TOI mode */
@@ -216,6 +220,7 @@ extern "C" my_bool wsrep_get_debug();
 
 extern "C" void wsrep_commit_ordered(MYSQL_THD thd);
 extern "C" my_bool wsrep_thd_is_applying(const MYSQL_THD thd);
+extern "C" bool wsrep_thd_set_wsrep_killed(MYSQL_THD thd);
 
 #endif
 #endif /* MYSQL_SERVICE_WSREP_INCLUDED */

--- a/mysql-test/suite/galera/r/galera_bf_kill.result
+++ b/mysql-test/suite/galera/r/galera_bf_kill.result
@@ -69,4 +69,34 @@ select * from t1;
 a	b
 2	1
 disconnect node_2a;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2a;
+truncate t1;
+insert into t1 values (1,0);
+begin;
+update t1 set b=2 where a=1;
+connection node_2;
+set session wsrep_sync_wait=0;
+connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2b;
+SET GLOBAL debug_dbug = "d,sync.before_wsrep_thd_abort";
+connection node_1;
+select * from t1;
+a	b
+1	0
+update t1 set b= 1 where a=1;
+connection node_2b;
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.before_wsrep_thd_abort_reached";
+connection node_2;
+SET DEBUG_SYNC= 'before_awake_no_mutex SIGNAL awake_reached WAIT_FOR continue_kill';
+connection node_2b;
+SET DEBUG_SYNC='now WAIT_FOR awake_reached';
+SET GLOBAL debug_dbug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.before_wsrep_thd_abort";
+SET DEBUG_SYNC = "now SIGNAL continue_kill";
+connection node_2;
+connection node_2a;
+select * from t1;
+connection node_2;
+SET DEBUG_SYNC = "RESET";
 drop table t1;

--- a/mysql-test/suite/galera/t/galera_bf_kill.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill.test
@@ -137,6 +137,89 @@ select * from t1;
 
 --disconnect node_2a
 
+#
+# Test case 7:
+# 1. Start a transaction on node_2,
+#    and leave it pending while holding a row locked
+# 2. set sync point pause applier
+# 3. send a conflicting write on node_1, it will pause
+#    at the sync point
+# 4. though another connection to node_2, kill the local
+#    transaction
+#
+
+#
+# connection node_2a runs a local transaction, that is victim of BF abort
+# and victim of KILL command by connection node_2
+#
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+truncate t1;
+insert into t1 values (1,0);
+
+# start a transaction that will conflict with later applier
+begin;
+update t1 set b=2 where a=1;
+
+--connection node_2
+set session wsrep_sync_wait=0;
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'root' AND COMMAND = 'Sleep' LIMIT 1
+--source include/wait_condition.inc
+
+--let $k_thread = `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'root' AND COMMAND = 'Sleep' LIMIT 1`
+
+# connection node_2b is for controlling debug syn points
+# first set a sync point for applier, to pause during BF aborting
+# and before THD::awake would be called
+#
+--connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2b
+SET GLOBAL debug_dbug = "d,sync.before_wsrep_thd_abort";
+
+#
+# replicate an update, which will BF abort the victim node_2a
+# however, while applier in node 2 is handling the abort,
+# it will pause in sync point set by node_2b
+#
+--connection node_1
+select * from t1;
+update t1 set b= 1 where a=1;
+
+#
+# wait until the applying of above update has reached the sync point
+# in node 2
+#
+--connection node_2b
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.before_wsrep_thd_abort_reached";
+
+--connection node_2
+#
+# pause KILL execution before awake
+#
+SET DEBUG_SYNC= 'before_awake_no_mutex SIGNAL awake_reached WAIT_FOR continue_kill';
+--disable_query_log
+--send_eval KILL $k_thread
+--enable_query_log
+
+
+--connection node_2b
+SET DEBUG_SYNC='now WAIT_FOR awake_reached';
+
+# release applier and KILL operator
+SET GLOBAL debug_dbug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.before_wsrep_thd_abort";
+SET DEBUG_SYNC = "now SIGNAL continue_kill";
+
+--connection node_2
+--reap
+
+--connection node_2a
+--error 0,1213
+select * from t1;
+
+--connection node_2
+SET DEBUG_SYNC = "RESET";
+
 drop table t1;
 
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -200,6 +200,16 @@ extern "C" void wsrep_handle_SR_rollback(THD *bf_thd,
 extern "C" my_bool wsrep_thd_bf_abort(THD *bf_thd, THD *victim_thd,
                                       my_bool signal)
 {
+  DBUG_EXECUTE_IF("sync.before_wsrep_thd_abort",
+                 {
+                   const char act[]=
+                     "now "
+                     "SIGNAL sync.before_wsrep_thd_abort_reached "
+                     "WAIT_FOR signal.before_wsrep_thd_abort";
+                   DBUG_ASSERT(!debug_sync_set_action(bf_thd,
+                                                      STRING_WITH_LEN(act)));
+                 };);
+
   my_bool ret= wsrep_bf_abort(bf_thd, victim_thd);
   /*
     Send awake signal if victim was BF aborted or does not
@@ -211,6 +221,14 @@ extern "C" my_bool wsrep_thd_bf_abort(THD *bf_thd, THD *victim_thd,
     mysql_mutex_assert_not_owner(&victim_thd->LOCK_thd_data);
     mysql_mutex_assert_not_owner(&victim_thd->LOCK_thd_kill);
     mysql_mutex_lock(&victim_thd->LOCK_thd_data);
+
+    if (victim_thd->wsrep_killed)
+    {
+      mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
+      return false;
+    }
+    victim_thd->wsrep_killed = true;
+    
     mysql_mutex_lock(&victim_thd->LOCK_thd_kill);
     victim_thd->awake_no_mutex(KILL_QUERY);
     mysql_mutex_unlock(&victim_thd->LOCK_thd_kill);
@@ -301,4 +319,14 @@ extern "C" void wsrep_commit_ordered(THD *thd)
   {
     thd->wsrep_cs().ordered_commit();
   }
+}
+
+extern "C" bool wsrep_thd_set_wsrep_killed(THD *thd)
+{
+  if (thd->wsrep_killed)
+  {
+    return true;
+  }
+  thd->wsrep_killed = true;
+  return false;
 }

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -674,6 +674,7 @@ THD::THD(my_thread_id id, bool is_wsrep_applier)
    wsrep_has_ignored_error(false),
    wsrep_replicate_GTID(false),
    wsrep_ignore_table(false),
+   wsrep_killed(false),
 
 /* wsrep-lib */
    m_wsrep_next_trx_id(WSREP_UNDEFINED_TRX_ID),
@@ -1288,6 +1289,7 @@ void THD::init()
   wsrep_affected_rows     = 0;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
   wsrep_replicate_GTID    = false;
+  wsrep_killed            = false;
 #endif /* WITH_WSREP */
 
   if (variables.sql_log_bin)
@@ -2126,6 +2128,9 @@ void THD::reset_killed()
     killed_err= 0;
     mysql_mutex_unlock(&LOCK_thd_kill);
   }
+#ifdef WITH_WSREP
+  wsrep_killed = false;
+#endif /* WITH_WSREP */
   DBUG_VOID_RETURN;
 }
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4854,6 +4854,7 @@ public:
     table updates from being replicated to other nodes via galera replication.
   */
   bool                      wsrep_ignore_table;
+  bool                      wsrep_killed;
   
 
   /*

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -9047,7 +9047,6 @@ kill_one_thread(THD *thd, longlong id, killed_state kill_signal, killed_type typ
   uint error= (type == KILL_TYPE_QUERY ? ER_NO_SUCH_QUERY : ER_NO_SUCH_THREAD);
   DBUG_ENTER("kill_one_thread");
   DBUG_PRINT("enter", ("id: %lld  signal: %u", id, (uint) kill_signal));
-  WSREP_DEBUG("kill_one_thread %llu", thd->thread_id);
   if (id && (tmp= find_thread_by_id(id, type == KILL_TYPE_QUERY)))
   {
     /*
@@ -9080,8 +9079,25 @@ kill_one_thread(THD *thd, longlong id, killed_state kill_signal, killed_type typ
         thd->security_ctx->user_matches(tmp->security_ctx))
 #endif /* WITH_WSREP */
     {
+#ifdef WITH_WSREP
+      DEBUG_SYNC(thd, "before_awake_no_mutex");
+      if (tmp->wsrep_killed)
+      {
+        /* victim is in hit list already, bail out */
+	WSREP_DEBUG("victim has wsrep_killed set, skipping awake()");
+	error = 0;
+      }
+      else
+      {
+#endif /* WITH_WSREP */
+      WSREP_DEBUG("kill_one_thread %llu, victim: %llu wsrep_killed %d by signal %d",
+                  thd->thread_id, id, tmp->wsrep_killed, kill_signal);
       tmp->awake_no_mutex(kill_signal);
+      WSREP_DEBUG("victim: %llu taken care of", id);
       error=0;
+#ifdef WITH_WSREP
+      }
+#endif /* WITH_WSREP */
     }
     else
       error= (type == KILL_TYPE_QUERY ? ER_KILL_QUERY_DENIED_ERROR :

--- a/sql/sql_plugin_services.ic
+++ b/sql/sql_plugin_services.ic
@@ -173,7 +173,8 @@ static struct wsrep_service_st wsrep_handler = {
   wsrep_get_sr_table_name,
   wsrep_get_debug,
   wsrep_commit_ordered,
-  wsrep_thd_is_applying
+  wsrep_thd_is_applying,
+  wsrep_thd_set_wsrep_killed
 };
 
 static struct thd_specifics_service_st thd_specifics_handler=

--- a/sql/wsrep_dummy.cc
+++ b/sql/wsrep_dummy.cc
@@ -142,3 +142,6 @@ void wsrep_log(void (*)(const char *, ...), const char *, ...)
 
 my_bool wsrep_thd_is_applying(const THD*)
 { return 0;}
+
+bool wsrep_thd_set_wsrep_killed(THD*)
+{ return 0;}

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18687,10 +18687,17 @@ wsrep_innobase_kill_one_trx(
 
 	/* Mark transaction as a victim for Galera abort */
 	victim_trx->lock.was_chosen_as_wsrep_victim= true;
+	if (wsrep_thd_set_wsrep_killed(thd))
+	{
+	  WSREP_DEBUG("innodb kill transaction skipped due to wsrep_killed");
+	  wsrep_thd_UNLOCK(thd);
+	  DBUG_RETURN(0);
+	}
 
 	/* Note that we need to release this as it will be acquired
 	below in wsrep-lib */
 	wsrep_thd_UNLOCK(thd);
+	DEBUG_SYNC(bf_thd, "before_wsrep_thd_abort");
 
 	if (wsrep_thd_bf_abort(bf_thd, thd, signal))
 	{


### PR DESCRIPTION
Added THD::wsrep_killed flag to synchronize who can kill the victim
This flag is set both when BF is called for from innodb and by KILL command
Either path of victim kill will bail out if victim's wsrep_killed is already
set to avoid mutex conflicts with the other aborter execution.

A new test case was added in galera.galera_bf_kill.test for scenario where
wsrep applier thread and manual KILL command try to kill same idle victim