### PR TITLE
MDEV-23272 Galera stack-use-after-scope error with ASAN build

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4188,16 +4188,7 @@ innobase_commit_low(
 #ifdef WITH_WSREP
 	const char* tmp = 0;
 	if (trx->is_wsrep()) {
-#ifdef WSREP_PROC_INFO
-		char info[64];
-		info[sizeof(info) - 1] = '\0';
-		snprintf(info, sizeof(info) - 1,
-			 "innobase_commit_low():trx_commit_for_mysql(%lld)",
-			 (long long) wsrep_thd_trx_seqno(trx->mysql_thd));
-		tmp = thd_proc_info(trx->mysql_thd, info);
-#else
 		tmp = thd_proc_info(trx->mysql_thd, "innobase_commit_low()");
-#endif /* WSREP_PROC_INFO */
 	}
 #endif /* WITH_WSREP */
 	if (trx_is_started(trx)) {

--- a/storage/xtradb/handler/ha_innodb.cc
+++ b/storage/xtradb/handler/ha_innodb.cc
@@ -4678,16 +4678,7 @@ innobase_commit_low(
 #ifdef WITH_WSREP
 	const char* tmp = 0;
 	if (trx->is_wsrep()) {
-#ifdef WSREP_PROC_INFO
-		char info[64];
-		info[sizeof(info) - 1] = '\0';
-		snprintf(info, sizeof(info) - 1,
-			 "innobase_commit_low():trx_commit_for_mysql(%lld)",
-			 (long long) wsrep_thd_trx_seqno(trx->mysql_thd));
-		tmp = thd_proc_info(trx->mysql_thd, info);
-#else
 		tmp = thd_proc_info(trx->mysql_thd, "innobase_commit_low()");
-#endif /* WSREP_PROC_INFO */
 	}
 #endif /* WITH_WSREP */
 	if (trx_is_started(trx)) {


### PR DESCRIPTION
THD proc info was assigned from stack allocated temporary buffer
which went out of scope immediately after assignment.

Fixed by removing the use of temp buffer and assign proc info
from string literal.