### PR TITLE
MDEV-21718 Assertion in wsrep::client_state::before_command().

### DIFF
--- a/mysql-test/suite/galera/r/mdev_21718.result
+++ b/mysql-test/suite/galera/r/mdev_21718.result
@@ -1,0 +1,16 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+connection node_1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC = "wsrep_before_before_command SIGNAL reached WAIT_FOR continue";
+COMMIT;
+connection node_1_ctrl;
+SET DEBUG_SYNC = "now WAIT_FOR reached";
+connection node_2;
+INSERT INTO t1 VALUES (1);
+connection node_1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE t1;
+SET DEBUG_SYNC = "RESET";

--- a/mysql-test/suite/galera/t/mdev_21718.cnf
+++ b/mysql-test/suite/galera/t/mdev_21718.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+thread-handling=pool-of-threads

--- a/mysql-test/suite/galera/t/mdev_21718.test
+++ b/mysql-test/suite/galera/t/mdev_21718.test
@@ -1,0 +1,33 @@
+#
+# MDEV-21718 Reproduce a case where BF abort after
+# client session acquires the ownership but before calls
+# before_command() causes an assertion in wsrep-lib.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+
+--let $galera_connection_name = node_1_ctrl
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+--connection node_1
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC = "wsrep_before_before_command SIGNAL reached WAIT_FOR continue";
+--send COMMIT
+
+--connection node_1_ctrl
+SET DEBUG_SYNC = "now WAIT_FOR reached";
+
+--connection node_2
+INSERT INTO t1 VALUES (1);
+
+# BF abort wakes up node_1 from sync wait.
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+DROP TABLE t1;
+SET DEBUG_SYNC = "RESET";

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1280,6 +1280,7 @@ bool do_command(THD *thd)
   command= fetch_command(thd, packet);
 
 #ifdef WITH_WSREP
+  DEBUG_SYNC(thd, "wsrep_before_before_command");
   /*
     Aborted by background rollbacker thread.
     Handle error here and jump straight to out


### PR DESCRIPTION
MDEV-21718 Assertion in wsrep::client_state::before_command().
    
An assertion
    
  `server_state_.rollback_mode() == wsrep::server_state::rm_async`
    
fired in before_command() when
- thread-handling was set to pool-of-threads and
- a BF abort happened between client session calls to
  wait_rollback_complete_and_acquire_ownership() and before_command().
    
This commit introduces a test case to reproduce the crash and
updates wsrep-lib submodule to fixed version.
