### PR TITLE
MDEV-23468: inline_mysql_socket_send: Assertion `mysql_socket.fd != -…

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2393,7 +2393,7 @@ static my_bool kill_remaining_threads(THD *thd, THD *caller_thd)
       thd != caller_thd)
   {
     WSREP_INFO("killing local connection: %lld", (longlong) thd->thread_id);
-    close_connection(thd, 0);
+    wsrep_close_thread(thd);
   }
 #endif
   return 0;


### PR DESCRIPTION
…1' failed on shutdown

Don't send end statement if we are are in WSREP disconnected state.