### PR TITLE
MENT-815 node restart overlaps with earlier still ongoing SST process

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -30,6 +30,7 @@ WSREP_SST_OPT_EXTRA_DEFAULT=""
 WSREP_SST_OPT_SUFFIX_DEFAULT=""
 WSREP_SST_OPT_SUFFIX_VALUE=""
 WSREP_SST_OPT_MYSQLD=""
+WSREP_SST_OPT_PROGRESS_FILE=""
 INNODB_DATA_HOME_DIR_ARG=""
 INNODB_LOG_GROUP_HOME_ARG=""
 INNODB_UNDO_DIR_ARG=""
@@ -245,6 +246,10 @@ case "$1" in
         readonly WSREP_SST_OPT_MYSQLD="$original_cmd"
         break
         ;;
+    '--progress-file')
+        readonly WSREP_SST_OPT_PROGRESS_FILE="$2"
+        shift
+        ;;
     *) # must be command
        # usage
        # exit 1
@@ -328,7 +333,7 @@ readonly WSREP_SST_OPT_PSWD
 
 if [ -n "${WSREP_SST_OPT_DATA:-}" ]
 then
-    SST_PROGRESS_FILE="$WSREP_SST_OPT_DATA/sst_in_progress"
+    SST_PROGRESS_FILE="$WSREP_SST_OPT_DATA/$WSREP_SST_OPT_PROGRESS_FILE"
 else
     SST_PROGRESS_FILE=""
 fi

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -765,25 +765,10 @@ int wsrep_init_server()
     initial_position= wsrep_server_initial_position();
 
      /* check if previous SST is still shutting down */
-    std::string sst_progress_file(working_dir);
-    sst_progress_file += "/sst_in_progress";
-    MY_STAT f_stat;
-    uint sst_file_wait = 0;
-    memset(&f_stat, 0, sizeof(MY_STAT));
-    while (my_stat(sst_progress_file.c_str(), &f_stat, MYF(0)))
-    {
-      if (sst_file_wait == 10)
-      {
-        WSREP_INFO("SST appears to be in progress, waiting max 10 secs to complete...");
-      }
-      if (sst_file_wait++ > 10)
-      {
-        WSREP_WARN("SST still in progress, will not startup, check if file is pending: %s",
-                   sst_progress_file.c_str());
-        return 1;
-      }
-      sleep(1);
+    if (wsrep_wait_for_sst_complete(working_dir)) {
+      return 1;
     }
+
     Wsrep_server_state::init_once(server_name,
                                   incoming_address,
                                   node_address,

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -33,6 +33,7 @@
 #define WSREP_SST_OPT_BINLOG   "--binlog"
 #define WSREP_SST_OPT_BINLOG_INDEX "--binlog-index"
 #define WSREP_SST_OPT_MYSQLD   "--mysqld-args"
+#define WSREP_SST_OPT_PROGRESS_FILE   "--progress-file"
 
 // mysqldump-specific options
 #define WSREP_SST_OPT_USER     "--user"
@@ -56,6 +57,7 @@
 #define WSREP_SST_DEFAULT      WSREP_SST_RSYNC
 #define WSREP_SST_ADDRESS_AUTO "AUTO"
 #define WSREP_SST_AUTH_MASK    "********"
+#define WSREP_SST_PROGRESS_FILE    "sst_in_progress"
 
 /* system variables */
 extern const char* wsrep_sst_method;
@@ -78,6 +80,7 @@ extern void wsrep_SE_init_wait();   /*! wait for SE init to complete */
 extern void wsrep_SE_init_done();   /*! signal that SE init is complte */
 extern void wsrep_SE_initialized(); /*! mark SE initialization complete */
 
+bool wsrep_wait_for_sst_complete(std::string working_dir);
 /**
    Return a string containing the state transfer request string.
    Note that the string may contain a '\0' in the middle.


### PR DESCRIPTION
In galera.galera_nbo_sst_slave test node restart can happen too soon, when earlier SST joiner process is still active in the node.
The fix in this pull request, does an additional check in mysqld startup phase to find out if SST progress file (sst_in_progress) is in mysql data directory.
(wsrep replication writes this file when SST begins, and removes the file when SST is finally over).
If SST progress file is found, mysqld startup phase will poll for 10 secs to see if the file is removed. If SST file remains still after this 10 sec polling, mysqld startup fails with error.
It could be that SST process has failed brutally and could not complete the cleanup phase, leaving a stale SST progress file behind.