### PR TITLE
 MENT-815 node restart overlaps with earlier still ongoing SST process

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -402,6 +402,14 @@ then
 
     RSYNC_PID="$WSREP_SST_OPT_DATA/$MODULE.pid"
 
+    # give some time for lingering rsync from previous SST to complete
+    check_round=0
+    while check_pid $RSYNC_PID && [ $check_round -lt 10 ]
+    do
+        check_round=`expr $check_round + 1`
+        sleep 1
+    done
+
     if check_pid $RSYNC_PID
     then
         wsrep_log_error "rsync daemon already running."


### PR DESCRIPTION
In galera.galera_nbo_sst_slave test node restart can happen too soon, when earlier SST joiner process is still active in the node.

This is second variant of fix for this issue. Here we only change rsync SST script to wait a little bit if lingering SST rsync is observed to be in execution.
We assume that the previous mysqld and SST processes have been already signaled to abort during earlier stataup attempt.

If other SST methods (than rsync) suffer from similar overlapping SST execution, they should be sorted out separately within each SST method handler scripts.