### PR TITLE
MENT-1047 Assertion `active() == false' failed with "XA START.."

### DIFF
--- a/mysql-test/suite/galera/r/MENT-1047.result
+++ b/mysql-test/suite/galera/r/MENT-1047.result
@@ -1,0 +1,4 @@
+connection node_2;
+connection node_1;
+XA START 'trx';
+ERROR 42000: This version of MariaDB doesn't yet support 'XA transactions with Galera replication'

--- a/mysql-test/suite/galera/t/MENT-1047.test
+++ b/mysql-test/suite/galera/t/MENT-1047.test
@@ -1,0 +1,7 @@
+#
+# MENT-1047 - Reject XA with Galera replication
+#
+--source include/galera_cluster.inc
+
+--error ER_NOT_SUPPORTED_YET
+XA START 'trx';

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5987,6 +5987,14 @@ mysql_execute_command(THD *thd)
     break;
   }
   case SQLCOM_XA_START:
+#ifdef WITH_WSREP
+    if (WSREP(thd))
+    {
+      my_error(ER_NOT_SUPPORTED_YET, MYF(0),
+               "XA transactions with Galera replication");
+      break;
+    }
+#endif /* WITH_WSREP */
     if (trans_xa_start(thd))
       goto error;
     my_ok(thd);


### PR DESCRIPTION
Galera replication does not support XA transactions yet. Reject any
attempt to `XA START` a transaction, if Galera is enabled.