### PR TITLE
MDEV-24775 galera.galera_FK_duplicate_client_insert test failure

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1211,6 +1211,7 @@ lock_rec_create_low(
 		if (c_lock->trx->lock.wait_thr) {
 
 			c_lock->trx->lock.was_chosen_as_deadlock_victim = TRUE;
+			c_lock->trx->lock.was_chosen_as_wsrep_victim = TRUE;
 
 			if (UNIV_UNLIKELY(wsrep_debug)) {
 				wsrep_print_wait_locks(c_lock);

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -132,7 +132,12 @@ dberr_t lock_wait(que_thr_t *thr)
     /* The lock has already been released or this transaction
     was chosen as a deadlock victim: no need to suspend */
 
-    if (trx->lock.was_chosen_as_deadlock_victim)
+#ifdef WITH_WSREP
+    if (trx->lock.was_chosen_as_deadlock_victim ||
+        trx->lock.was_chosen_as_wsrep_victim)
+#else
+      if (trx->lock.was_chosen_as_deadlock_victim)
+#endif /* WITH_WSREP */
     {
       trx->error_state= DB_DEADLOCK;
       trx->lock.was_chosen_as_deadlock_victim= false;


### PR DESCRIPTION
galera_FK_duplicate_client_insert hangs in 10.6 HEAD versions.
The hang happens because high priority replication applier can not successfully BF abort a local transcaction holding a blocking innodb lock.
In the test scenario, the blocking local transaction is waiting for another innodb lock held by second local transaction.
The replication applier is trying to abort the blocking transaction by lock_cancel_waiting_and_release() call, which removes the local transaction from waiting state, and sets innodb transaction error_state to DB_DEADLOCK.
However, at the time of BF aborting, the blocking local transaction has not quite yet hibernated in lock waiting, lock0wait.cc:lock_wait() has sync point  lock_wait_suspend_thread_enter,where the local trasnaction is stopped.
Fix for MDEV-24671 has refactored lock_wait() function to unconditionally overwrite trx::error_state by:

  trx->error_state= DB_SUCCESS;

This happens after sync point lock_wait_suspend_thread_enter, and therefore when the local transaction resumes after sync point wait, it will miss the BF abort status. And this further, keeps the replication applier to wait eternally for the local transaction's blocking lock.

The fix in this PR is to use trx::was_chosen_as_wsrep_victim flag, to signal the victim of BF abort.