### PR TITLE
MDEV-21697: Galera assertion !wsrep_has_changes(thd) || (thd->lex->sq…

### DIFF
--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -4724,7 +4724,8 @@ bool select_create::send_eof()
   if (!table->s->tmp_table)
   {
 #ifdef WITH_WSREP
-    if (WSREP(thd))
+    if (WSREP(thd) &&
+        table->file->ht->db_type == DB_TYPE_INNODB)
     {
       if (thd->wsrep_trx_id() == WSREP_UNDEFINED_TRX_ID)
       {


### PR DESCRIPTION
…l_command == SQLCOM_CREATE_TABLE && !thd->is_current_stmt_binlog_format_row())

Prevent adding WSREP keys with CTAS when table is is not InnoDB.