### PR TITLE
MDEV-24956: ALTER TABLE not replicated with Galera in MariaDB 10.5.9

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
@@ -1,0 +1,89 @@
+connection node_2;
+connection node_1;
+connect node_5, 127.0.0.1, root, , test, $NODE_MYPORT_5;
+connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4;
+connection node_4;
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=NODE_MYPORT_1, master_use_gtid=current_pos;;
+START SLAVE;
+include/wait_for_slave_to_start.inc
+connection node_1;
+CREATE TABLE t1(c1 INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, c2 INTEGER);
+INSERT INTO t1(c2) VALUES(1);
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_3;
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
+1
+connection node_1;
+include/save_master_gtid.inc
+connection node_4;
+include/sync_with_master_gtid.inc
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
+1
+connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6;
+connection node_6;
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
+1
+connection node_2;
+ALTER TABLE t1 ADD COLUMN t3 INTEGER;
+Node 2 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+COUNT(*) = 3
+1
+connection node_3;
+Node 3 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+COUNT(*) = 3
+1
+connection node_1;
+include/save_master_gtid.inc
+connection node_4;
+include/sync_with_master_gtid.inc
+Node 4 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+COUNT(*) = 3
+1
+connection node_6;
+Node 6 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+COUNT(*) = 3
+1
+connection node_2;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+connection node_1;
+connection node_4;
+connection node_6;
+connection node_1;
+DROP TABLE t1;
+connection node_4;
+STOP SLAVE;
+RESET SLAVE;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+SET GLOBAL GTID_SLAVE_POS="";
+connection node_1;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+connection node_2;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+connection node_3;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+connection node_5;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+connection node_6;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;

--- a/mysql-test/suite/galera_3nodes/t/galera_2_cluster.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_2_cluster.cnf
@@ -1,0 +1,25 @@
+!include ../galera_2x3nodes.cnf
+
+[mysqld.1]
+wsrep_gtid_domain_id=1
+server-id=11
+
+[mysqld.2]
+wsrep_gtid_domain_id=1
+server-id=12
+
+[mysqld.3]
+wsrep_gtid_domain_id=1
+server-id=13
+
+[mysqld.4]
+wsrep_gtid_domain_id=2
+server-id=21
+
+[mysqld.5]
+wsrep_gtid_domain_id=2
+server-id=22
+
+[mysqld.6]
+wsrep_gtid_domain_id=2
+server-id=23

--- a/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
@@ -1,0 +1,148 @@
+#
+# This test creates 2x3 nodes galera cluster.
+#
+#       A(1) <-> B(2) <-> C(3)     {Galera cluster 1}
+#       |                          {Circular Async replication}
+#       D(4) <-> E(5) <-> F(6)     {Galera cluster 2}
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connect node_5, 127.0.0.1, root, , test, $NODE_MYPORT_5
+
+--connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4
+--connection node_4
+
+--replace_result $NODE_MYPORT_1 NODE_MYPORT_1
+--eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$NODE_MYPORT_1, master_use_gtid=current_pos;
+START SLAVE;
+--source include/wait_for_slave_to_start.inc
+
+#
+# CREATE TABLE & INSERT
+#
+
+--connection node_1
+
+CREATE TABLE t1(c1 INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, c2 INTEGER);
+INSERT INTO t1(c2) VALUES(1);
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
+
+SELECT COUNT(*) = 1 FROM t1;
+
+--connection node_1
+--source include/save_master_gtid.inc
+
+--connection node_4
+--source include/sync_with_master_gtid.inc
+
+SELECT COUNT(*) = 1 FROM t1;
+
+--connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6
+--connection node_6
+
+SELECT COUNT(*) = 1 FROM t1;
+
+#
+# ALTER TABLE
+#
+
+--connection node_2
+
+ALTER TABLE t1 ADD COLUMN t3 INTEGER;
+--echo Node 2 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+
+--connection node_3
+
+--echo Node 3 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+
+--connection node_1
+--source include/save_master_gtid.inc
+
+--connection node_4
+--source include/sync_with_master_gtid.inc
+
+--echo Node 4 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+
+--connection node_6
+
+--echo Node 6 column number AFTER ALTER
+SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
+
+#
+# OPTIMIZE TABLE
+#
+
+--connection node_2
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+OPTIMIZE TABLE t1;
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
+
+--connection node_4
+
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
+
+--connection node_6
+
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
+
+#
+# Cleanup
+#
+
+--connection node_1
+
+DROP TABLE t1;
+
+--connection node_4
+
+STOP SLAVE;
+RESET SLAVE;
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+SET GLOBAL GTID_SLAVE_POS="";
+
+--connection node_1
+
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+
+--connection node_2
+
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+
+--connection node_3
+
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+
+--connection node_5
+
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;
+
+--connection node_6
+
+SET GLOBAL wsrep_on = OFF;
+RESET MASTER;
+SET GLOBAL wsrep_on = ON;

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -447,7 +447,7 @@ dbug_err:
   */
 static bool wsrep_toi_replication(THD *thd, TABLE_LIST *tables)
 {
-  if (!WSREP(thd) || !WSREP_CLIENT(thd)) return false;
+  if (!WSREP(thd)) return true;
 
   LEX *lex= thd->lex;
   /* only handle OPTIMIZE and REPAIR here */

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -471,7 +471,7 @@ bool Sql_cmd_alter_table::execute(THD *thd)
   if (check_grant(thd, priv_needed, first_table, FALSE, UINT_MAX, FALSE))
     DBUG_RETURN(TRUE);                  /* purecov: inspected */
 #ifdef WITH_WSREP
-  if (WSREP(thd) && WSREP_CLIENT(thd) &&
+  if (WSREP(thd) &&
       (!thd->is_current_stmt_binlog_format_row() ||
        !thd->find_temporary_table(first_table)))
   {


### PR DESCRIPTION
`ALTER TABLE` is not replicated in cluster if command is received over async replication.
Removed condition that ALTER is only replicated `WSREP_CLIENT` which is not true for replication
threads.