### PR TITLE
MDEV-25740 Assertion `!wsrep_has_changes(thd) || (thd->lex->sql_comm…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-25740.result
+++ b/mysql-test/suite/galera/r/MDEV-25740.result
@@ -1,0 +1,9 @@
+connection node_2;
+connection node_1;
+SET AUTOCOMMIT = OFF;
+SET completion_type = CHAIN;
+CREATE TABLE t1(f1 INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+ROLLBACK;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-25740.test
+++ b/mysql-test/suite/galera/t/MDEV-25740.test
@@ -1,0 +1,14 @@
+#
+# When `completion_type = CHAIN` is used, transaction started should not have previous writeset.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SET AUTOCOMMIT = OFF;
+SET completion_type = CHAIN;
+CREATE TABLE t1(f1 INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+ROLLBACK;
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5752,6 +5752,11 @@ mysql_execute_command(THD *thd)
     /* Begin transaction with the same isolation level. */
     if (tx_chain)
     {
+#ifdef WITH_WSREP
+      /* If there are pending changes after rollback we should clear them */
+      if (wsrep_on(thd) && wsrep_has_changes(thd))
+        wsrep_after_statement(thd);
+#endif
       if (trans_begin(thd))
         goto error;
     }


### PR DESCRIPTION
…and == SQLCOM_CREATE_TABLE && !thd->is_current_stmt_binlog_format_row())' failed in void wsrep_commit_empty(THD*, bool)

Using ROLLBACK with `completion_type = CHAIN` result in start of
transaction and implicit commit before previous WSREP internal data is
cleared.