### PR TITLE
MDEV-22708 Assertion `!mysql_bin_log.is_open() || thd.is_current_stmt…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-22708.result
+++ b/mysql-test/suite/galera/r/MDEV-22708.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+SET @wsrep_forced_binlog_format_saved = @@GLOBAL.wsrep_forced_binlog_format;
+SET @@GLOBAL.wsrep_forced_binlog_format = STATEMENT;
+CREATE TABLE t1(c INT PRIMARY KEY) ENGINE = MyISAM;
+INSERT DELAYED INTO t1 VALUES (1),(2),(3);
+SELECT SLEEP(1);
+SLEEP(1)
+0
+DROP TABLE t1;
+SET @@GLOBAL.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_saved;

--- a/mysql-test/suite/galera/t/MDEV-22708.cnf
+++ b/mysql-test/suite/galera/t/MDEV-22708.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+log-bin

--- a/mysql-test/suite/galera/t/MDEV-22708.test
+++ b/mysql-test/suite/galera/t/MDEV-22708.test
@@ -1,0 +1,14 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SET @wsrep_forced_binlog_format_saved = @@GLOBAL.wsrep_forced_binlog_format;
+SET @@GLOBAL.wsrep_forced_binlog_format = STATEMENT;
+
+CREATE TABLE t1(c INT PRIMARY KEY) ENGINE = MyISAM;
+
+INSERT DELAYED INTO t1 VALUES (1),(2),(3);
+SELECT SLEEP(1);
+
+DROP TABLE t1;
+
+SET @@GLOBAL.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_saved;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -474,7 +474,7 @@ void upgrade_lock_type(THD *thd, thr_lock_type *lock_type,
     }
 
     bool log_on= (thd->variables.option_bits & OPTION_BIN_LOG);
-    if (global_system_variables.binlog_format == BINLOG_FORMAT_STMT &&
+    if (thd->wsrep_binlog_format() == BINLOG_FORMAT_STMT &&
         log_on && mysql_bin_log.is_open())
     {
       /*


### PR DESCRIPTION
…_binlog_format_row()' failed in Delayed_insert::handle_inserts and in Diagnostics_area::set_eof_status

Variable wsrep_forced_binlog_format has higher priority than
binlog_format. In situation where STATEMENT is used and DELAYED INSERT
is executing we should fall back to non-delay INSERT.