### PR TITLE
Make test galera_sr_kill_slave_before_apply deterministic

### DIFF
--- a/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_before_apply.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_before_apply.result
@@ -32,14 +32,18 @@ Killing server ...
 # restart
 connection node_1;
 COMMIT;
-SELECT COUNT(*) = 5 FROM t1;
-COUNT(*) = 5
+count_match
 1
+count_match
+1
+connection node_1;
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+0
 connection node_2;
-SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-COUNT(*) = 0
-1
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
+COUNT(*)
+0
 connection node_1;
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera_3nodes_sr/suite.pm
+++ b/mysql-test/suite/galera_3nodes_sr/suite.pm
@@ -37,6 +37,7 @@ push @::global_suppressions,
      qr|WSREP: Protocol violation. JOIN message sender .* is not in state transfer \(SYNCED\). Message ignored.|,
      qr|WSREP: Protocol violation. JOIN message sender .* is not in state transfer \(JOINED\). Message ignored.|,
      qr(WSREP: Action message in non-primary configuration from member [0-9]*),
+     qr|WSREP: .*core_handle_uuid_msg.*|,
      qr(WSREP: --wsrep-causal-reads=ON takes precedence over --wsrep-sync-wait=0. WSREP_SYNC_WAIT_BEFORE_READ is on),
      qr(WSREP: JOIN message from member .* in non-primary configuration. Ignored.),
    );

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_before_apply.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_before_apply.test
@@ -51,20 +51,37 @@ INSERT INTO t1 VALUES (5);
 --source include/kill_galera.inc
 --source include/start_mysqld.inc
 
-# Expect that the SR table will get some entries after the restart
---let $wait_condition = SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
---source include/wait_condition.inc
+--connection node_1
+# The following COMMIT usually succeeds. Due to timing,
+# it is however possible that this node delivers the same
+# view twice during configuration change. In which case
+# this transaction will mistakenly be considered orphaned,
+# and aborted.
+--error 0, ER_LOCK_DEADLOCK
+COMMIT;
+
+
+--disable_query_log
+if ($mysql_errno == 0) {
+    --connection node_1
+    SELECT COUNT(*) = 5 AS count_match FROM t1;
+    --connection node_2
+    SELECT COUNT(*) = 5 AS count_match FROM t1;
+}
+
+if ($mysql_errno == 1213) {
+    --connection node_1
+    SELECT COUNT(*) = 0 AS count_match FROM t1;
+    --connection node_2
+    SELECT COUNT(*) = 0 AS count_match FROM t1;
+}
+--enable_query_log
 
 --connection node_1
-COMMIT;
-SELECT COUNT(*) = 5 FROM t1;
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 --connection node_2
-SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
---let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
---source include/wait_condition.inc
-
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 --connection node_1
 DROP TABLE t1;


### PR DESCRIPTION
* Handle the (rare) case where the ongoing transaction is aborted, if
  the ongoing transaction is considered orphaned. This happens if the
  node delivers two consecutive primary views with the
* Add ignorable warning to suite.pm