### PR TITLE
Cleanup wsrep_last_committed_id(), wsrep_node_uuid()

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2623,20 +2623,6 @@ void wsrep_wait_appliers_close(THD *thd)
   */
 }
 
-void
-wsrep_last_committed_id(wsrep_gtid_t* gtid)
-{
-  wsrep::gtid ret= Wsrep_server_state::instance().last_committed_gtid();
-  memcpy(gtid->uuid.data, ret.id().data(), sizeof(gtid->uuid.data));
-  gtid->seqno= ret.seqno().get();
-}
-
-void
-wsrep_node_uuid(wsrep_uuid_t& uuid)
-{
-  uuid= node_uuid;
-}
-
 int wsrep_must_ignore_error(THD* thd)
 {
   const int error= thd->get_stmt_da()->sql_errno();

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -210,7 +210,6 @@ extern bool wsrep_must_sync_wait (THD* thd, uint mask= WSREP_SYNC_WAIT_BEFORE_RE
 extern bool wsrep_sync_wait (THD* thd, uint mask= WSREP_SYNC_WAIT_BEFORE_READ);
 extern enum wsrep::provider::status
 wsrep_sync_wait_upto (THD* thd, wsrep_gtid_t* upto, int timeout);
-extern void wsrep_last_committed_id (wsrep_gtid_t* gtid);
 extern int  wsrep_check_opts();
 extern void wsrep_prepend_PATH (const char* path);
 extern bool wsrep_append_fk_parent_table(THD* thd, TABLE_LIST* table, wsrep::key_array* keys);
@@ -382,7 +381,6 @@ bool wsrep_node_is_synced();
 void wsrep_init_SR();
 void wsrep_verify_SE_checkpoint(const wsrep_uuid_t& uuid, wsrep_seqno_t seqno);
 int wsrep_replay_from_SR_store(THD*, const wsrep_trx_meta_t&);
-void wsrep_node_uuid(wsrep_uuid_t&);
 
 class Log_event;
 int wsrep_ignored_error_code(Log_event* ev, int error);


### PR DESCRIPTION
Wsrep-lib server_state::last_committed_gtid() methods were
removed. Remove calling wsrep_last_committed_id() from server side
(was not used for anything). Also remove wsrep_node_uuid() which is
dead code.
