### PR TITLE
MDEV-26803 PA unsafety with FK cascade delete operation

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -88,6 +88,7 @@ extern struct wsrep_service_st {
                                                                 unsigned long long trx_id);
   void                        (*wsrep_thd_kill_LOCK_func)(const MYSQL_THD thd);
   void                        (*wsrep_thd_kill_UNLOCK_func)(const MYSQL_THD thd);
+  void                        (*wsrep_thd_set_wsrep_PA_unsafe_func)(MYSQL_THD thd);
 } *wsrep_service;
 
 #define MYSQL_SERVICE_WSREP_INCLUDED
@@ -131,6 +132,7 @@ extern struct wsrep_service_st {
 #define wsrep_thd_is_applying(T) wsrep_service->wsrep_thd_is_applying_func(T)
 #define wsrep_thd_set_wsrep_aborter(T) wsrep_service->wsrep_thd_set_wsrep_aborter_func(T1, T2)
 #define wsrep_report_bf_lock_wait(T,I) wsrep_service->wsrep_report_bf_lock_wait(T,I)
+#define wsrep_thd_set_PA_unsafe(T) wsrep_service->wsrep_thd_set_PA_unsafe_func(T)
 #else
 
 #define MYSQL_SERVICE_WSREP_STATIC_INCLUDED
@@ -229,5 +231,7 @@ extern "C" my_bool wsrep_thd_is_applying(const MYSQL_THD thd);
 extern "C" bool wsrep_thd_set_wsrep_aborter(MYSQL_THD bf_thd, MYSQL_THD victim_thd);
 extern "C" void wsrep_report_bf_lock_wait(const THD *thd,
                                           unsigned long long trx_id);
+/* declare parallel applying unsafety for the THD */
+extern "C" void wsrep_thd_set_PA_unsafe(MYSQL_THD thd);
 #endif
 #endif /* MYSQL_SERVICE_WSREP_INCLUDED */

--- a/mysql-test/suite/galera/r/galera_fk_cascade_delete.result
+++ b/mysql-test/suite/galera/r/galera_fk_cascade_delete.result
@@ -48,3 +48,25 @@ id	parent_id
 DROP TABLE child;
 DROP TABLE parent;
 DROP TABLE grandparent;
+
+Scenario 2, testing PA applying with FK cascade delete
+
+CREATE TABLE p1 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE p2 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p1_id INTEGER, p2_id INTEGER,
+f2 INTEGER,
+CONSTRAINT fk_1 FOREIGN KEY (p1_id) REFERENCES p1 (f1)
+ON DELETE CASCADE,
+CONSTRAINT fk_2 FOREIGN KEY (p2_id) REFERENCES p2 (f1)
+ON DELETE CASCADE);
+connection node_2;
+set global wsrep_slave_threads=DEFAULT;
+SELECT * FROM p1;
+f1	f2
+SELECT * FROM p2;
+f1	f2
+SELECT * FROM c;
+f1	p1_id	p2_id	f2
+connection node_1;
+DROP TABLE c;
+DROP TABLE p1,p2;

--- a/mysql-test/suite/galera/t/galera_fk_cascade_delete.test
+++ b/mysql-test/suite/galera/t/galera_fk_cascade_delete.test
@@ -68,3 +68,52 @@ SELECT * FROM child;
 DROP TABLE child;
 DROP TABLE parent;
 DROP TABLE grandparent;
+
+--echo
+--echo Scenario 2, testing PA applying with FK cascade delete
+--echo
+
+CREATE TABLE p1 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE p2 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=INNODB;
+CREATE TABLE c (f1 INTEGER PRIMARY KEY, p1_id INTEGER, p2_id INTEGER,
+                f2 INTEGER,
+                CONSTRAINT fk_1 FOREIGN KEY (p1_id) REFERENCES p1 (f1)
+                    ON DELETE CASCADE,
+                CONSTRAINT fk_2 FOREIGN KEY (p2_id) REFERENCES p2 (f1)
+                    ON DELETE CASCADE);
+
+--let $count = 100
+--disable_query_log
+while ($count)
+{
+    --eval INSERT INTO p1 VALUES ($count, 0);
+    --eval INSERT INTO p2 VALUES ($count, 0);
+    --eval INSERT INTO c VALUES ($count, $count, $count, 0);
+    --dec $count
+}
+
+--connection node_2
+set global wsrep_slave_threads=2;
+
+--connection node_1
+--let $count = 100
+while ($count)
+{
+    --eval DELETE FROM p2 WHERE f1=$count;
+    --eval DELETE FROM p1 WHERE f1=$count;
+
+--dec $count
+}
+--enable_query_log
+
+--connection node_2
+set global wsrep_slave_threads=DEFAULT;
+
+
+SELECT * FROM p1;
+SELECT * FROM p2;
+SELECT * FROM c;
+
+--connection node_1
+DROP TABLE c;
+DROP TABLE p1,p2;

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -381,3 +381,11 @@ extern "C" void wsrep_report_bf_lock_wait(const THD *thd,
                 wsrep_thd_query(thd));
   }
 }
+
+extern "C" void  wsrep_thd_set_PA_unsafe(THD *thd)
+{
+  if (thd && thd->wsrep_cs().mark_transaction_pa_unsafe())
+  {
+    WSREP_DEBUG("session does not have active transaction, can not mark as PA unsafe");
+  }
+}

--- a/sql/sql_plugin_services.ic
+++ b/sql/sql_plugin_services.ic
@@ -176,7 +176,8 @@ static struct wsrep_service_st wsrep_handler = {
   wsrep_thd_set_wsrep_aborter,
   wsrep_report_bf_lock_wait,
   wsrep_thd_kill_LOCK,
-  wsrep_thd_kill_UNLOCK
+  wsrep_thd_kill_UNLOCK,
+  wsrep_thd_set_PA_unsafe
 };
 
 static struct thd_specifics_service_st thd_specifics_handler=

--- a/sql/wsrep_dummy.cc
+++ b/sql/wsrep_dummy.cc
@@ -147,3 +147,7 @@ bool wsrep_thd_set_wsrep_aborter(THD*, THD*)
 void wsrep_report_bf_lock_wait(const THD*,
                                unsigned long long)
 {}
+
+void wsrep_thd_set_PA_unsafe(THD*)
+{}
+

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -90,8 +90,6 @@ void wsrep_create_rollbacker();
 bool wsrep_bf_abort(THD* bf_thd, THD* victim_thd);
 int  wsrep_abort_thd(THD *bf_thd_ptr, THD *victim_thd_ptr, my_bool signal);
 
-extern void  wsrep_thd_set_PA_safe(void *thd_ptr, my_bool safe);
-
 /*
   Helper methods to deal with thread local storage.
   The purpose of these methods is to hide the details of thread

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1328,6 +1328,8 @@ row_ins_foreign_check_on_constraint(
 		ib::info() << "WSREP: foreign key append failed: " <<  err;
 		goto nonstandard_exit_func;
 	}
+
+	wsrep_thd_set_PA_unsafe(trx->mysql_thd);
 #endif /* WITH_WSREP */
 	mtr_commit(mtr);
 


### PR DESCRIPTION
This commit has a mtr test for two two transactions delete a row from
two separate tables, which will cascade a FK delete for the same row in
a third table.Second replica node is configured with 2 applier threads,
and the test will fail if these two transactions are applied in parallel.

The fix, in this commit, is mark a transaction as unsafe for parallel applying
when it traverses into cascade delete operation.