### PR TITLE
MDEV-27649 PS conflict handling causing node crash

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -701,6 +701,7 @@ THD::THD(my_thread_id id, bool is_wsrep_applier)
    wsrep_current_gtid_seqno(0),
    wsrep_affected_rows(0),
    wsrep_has_ignored_error(false),
+   wsrep_delayed_BF_abort(false),
    wsrep_ignore_table(false),
    wsrep_aborter(0),
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5048,7 +5048,7 @@ public:
   uint64                    wsrep_current_gtid_seqno;
   ulong                     wsrep_affected_rows;
   bool                      wsrep_has_ignored_error;
-
+  bool                      wsrep_delayed_BF_abort;
   /*
     When enabled, do not replicate/binlog updates from the current table that's
     being processed. At the moment, it is used to keep mysql.gtid_slave_pos

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1310,7 +1310,13 @@ bool do_command(THD *thd)
     DBUG_ASSERT(!thd->mdl_context.has_locks());
     DBUG_ASSERT(!thd->get_stmt_da()->is_set());
     /* We let COM_QUIT and COM_STMT_CLOSE to execute even if wsrep aborted. */
-    if (command != COM_STMT_CLOSE &&
+    if (command == COM_STMT_EXECUTE)
+    {
+      WSREP_DEBUG("PS BF aborted at do_command");
+      thd->wsrep_delayed_BF_abort= true;
+    }
+    if (command != COM_STMT_CLOSE   &&
+	command != COM_STMT_EXECUTE &&
         command != COM_QUIT)
     {
       my_error(ER_LOCK_DEADLOCK, MYF(0));
@@ -1382,6 +1388,17 @@ out:
     /* there was a command to process, and before_command() has been called */
     if (unlikely(wsrep_service_started))
       wsrep_after_command_after_result(thd);
+  }
+
+  if (thd->wsrep_delayed_BF_abort)
+  {
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      WSREP_DEBUG("Deadlock error for PS query: %s", thd->query());
+      thd->reset_killed();
+      thd->mysys_var->abort     = 0;
+      thd->wsrep_retry_counter  = 0;
+
+      thd->wsrep_delayed_BF_abort= false;
   }
 #endif /* WITH_WSREP */
   DBUG_RETURN(return_value);

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -4487,7 +4487,13 @@ Prepared_statement::execute_loop(String *expanded_query,
 
   if (set_parameters(expanded_query, packet, packet_end))
     return TRUE;
-
+#ifdef WITH_WSREP
+  if (thd->wsrep_delayed_BF_abort)
+  {
+    WSREP_DEBUG("delayed BF abort, quitting execute_loop, stmt: %d", id);
+    return TRUE;
+  }
+#endif /* WITH_WSREP */
 reexecute:
   // Make sure that reprepare() did not create any new Items.
   DBUG_ASSERT(thd->free_list == NULL);


### PR DESCRIPTION
Handling BF abort for prepared statement execution so that EXECUTE will continue
until parameter setup is complete, before BF abort bails out the statement execution.