### PR TITLE
Reduce compilation dependencies on wsrep_mysqld.h

### DIFF
--- a/include/wsrep.h
+++ b/include/wsrep.h
@@ -17,44 +17,46 @@
 #define WSREP_INCLUDED
 
 #include <my_config.h>
+#include "log.h"
 
 #ifdef WITH_WSREP
 #define IF_WSREP(A,B) A
 #define DBUG_ASSERT_IF_WSREP(A) DBUG_ASSERT(A)
 
-#define WSREP_MYSQL_DB (char *)"mysql"
-
-#define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_)              \
-  if (WSREP_ON && WSREP(thd) && wsrep_to_isolation_begin(thd, db_, table_, table_list_)) \
-    goto wsrep_error_label;
-
-#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_, fk_tables_) \
-  if (WSREP(thd) && wsrep_thd_is_local(thd) &&                          \
-      wsrep_to_isolation_begin(thd, db_, table_,                        \
-                               table_list_, alter_info_, fk_tables_))
-
-#define WSREP_TO_ISOLATION_END                                          \
-  if ((WSREP(thd) && wsrep_thd_is_local_toi(thd)) ||                    \
-      wsrep_thd_is_in_rsu(thd))                                         \
-    wsrep_to_isolation_end(thd);
-
-/*
-  Checks if lex->no_write_to_binlog is set for statements that use LOCAL or
-  NO_WRITE_TO_BINLOG.
-*/
-#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)                   \
-  if (WSREP(thd) && !thd->lex->no_write_to_binlog                                   \
-         && wsrep_to_isolation_begin(thd, db_, table_, table_list_)) goto wsrep_error_label;
+extern ulong wsrep_debug; // wsrep_mysqld.cc
+extern void WSREP_LOG(void (*fun)(const char* fmt, ...), const char* fmt, ...);
 
 #define WSREP_DEBUG(...)                                                \
     if (wsrep_debug)     WSREP_LOG(sql_print_information, ##__VA_ARGS__)
 #define WSREP_INFO(...)  WSREP_LOG(sql_print_information, ##__VA_ARGS__)
 #define WSREP_WARN(...)  WSREP_LOG(sql_print_warning,     ##__VA_ARGS__)
 #define WSREP_ERROR(...) WSREP_LOG(sql_print_error,       ##__VA_ARGS__)
+#define WSREP_UNKNOWN(fmt, ...) WSREP_ERROR("UNKNOWN: " fmt, ##__VA_ARGS__)
 
-#define WSREP_SYNC_WAIT(thd_, before_)                                  \
-    { if (WSREP_CLIENT(thd_) &&                                         \
-          wsrep_sync_wait(thd_, before_)) goto wsrep_error_label; }
+#define WSREP_LOG_CONFLICT_THD(thd, role)                               \
+  WSREP_INFO("%s: \n "                                                  \
+             "  THD: %lu, mode: %s, state: %s, conflict: %s, seqno: %lld\n " \
+             "  SQL: %s",                                               \
+             role,                                                      \
+             thd_get_thread_id(thd),                                    \
+             wsrep_thd_client_mode_str(thd),                            \
+             wsrep_thd_client_state_str(thd),                           \
+             wsrep_thd_transaction_state_str(thd),                      \
+             wsrep_thd_trx_seqno(thd),                                  \
+             wsrep_thd_query(thd)                                       \
+            );
+
+#define WSREP_LOG_CONFLICT(bf_thd, victim_thd, bf_abort)                \
+  if (wsrep_debug || wsrep_log_conflicts)                               \
+  {                                                                     \
+    WSREP_INFO("cluster conflict due to %s for threads:",               \
+               (bf_abort) ? "high priority abort" : "certification failure" \
+              );                                                        \
+    if (bf_thd)     WSREP_LOG_CONFLICT_THD(bf_thd, "Winning thread");   \
+    if (victim_thd) WSREP_LOG_CONFLICT_THD(victim_thd, "Victim thread"); \
+    WSREP_INFO("context: %s:%d", __FILE__, __LINE__); \
+  }
+
 
 #else /* !WITH_WSREP */
 
@@ -67,11 +69,6 @@
 //#define WSREP_INFO(...)
 //#define WSREP_WARN(...)
 #define WSREP_ERROR(...)
-#define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_) do { } while(0)
-#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_, fk_tables_)
-#define WSREP_TO_ISOLATION_END
-#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)
-#define WSREP_SYNC_WAIT(thd_, before_)
 #endif /* WITH_WSREP */
 
 #endif /* WSREP_INCLUDED */

--- a/sql/backup.cc
+++ b/sql/backup.cc
@@ -34,7 +34,7 @@
 #include "sql_insert.h"                         // kill_delayed_threads
 #include "sql_handler.h"                        // mysql_ha_cleanup_no_free
 #include <my_sys.h>
-#include "wsrep_mysqld.h"
+#include "wsrep_server_state.h"
 
 static const char *stage_names[]=
 {"START", "FLUSH", "BLOCK_DDL", "BLOCK_COMMIT", "END", 0};

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -34,6 +34,9 @@
 #include "sp_head.h" // for Stored_program_creation_ctx
 #include "set_var.h"
 #include "lock.h"   // lock_object_name
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 /**
   @addtogroup Event_Scheduler

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -55,6 +55,9 @@
 #include "debug_sync.h"
 #include "sql_base.h"
 #include "sql_cte.h"
+#ifdef WITH_WSREP
+#include "mysql/service_wsrep.h"
+#endif /* WITH_WSREP */
 
 #ifdef NO_EMBEDDED_ACCESS_CHECKS
 #define sp_restore_security_context(A,B) while (0) {}

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -5362,8 +5362,8 @@ String *Item_temptable_rowid::val_str(String *str)
   return &str_value;
 }
 #ifdef WITH_WSREP
-
 #include "wsrep_mysqld.h"
+#include "wsrep_server_state.h"
 
 String *Item_func_wsrep_last_written_gtid::val_str_ascii(String *str)
 {

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -80,7 +80,10 @@
 #include "sql_acl.h"                       // SUPER_ACL
 #include "sql_handler.h"
 #include <hash.h>
+#ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
+#include "wsrep_server_state.h"
+#endif
 
 /**
   @defgroup Locking Locking

--- a/sql/log.h
+++ b/sql/log.h
@@ -18,7 +18,6 @@
 #define LOG_H
 
 #include "handler.h"                            /* my_xid */
-#include "wsrep_mysqld.h"
 #include "rpl_constants.h"
 
 class Relay_log_info;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -43,8 +43,10 @@
 #include <mysql/psi/mysql_statement.h>
 #include <strfunc.h>
 #include "compat56.h"
-#include "wsrep_mysqld.h"
 #include "sql_insert.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif /* WITH_WSREP */
 #else
 #include "mysqld_error.h"
 #endif /* MYSQL_CLIENT */

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -24,6 +24,9 @@
 #include <mysql/plugin.h>
 #include <mysql/service_thd_wait.h>
 #include <mysql/psi/mysql_stage.h>
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 #ifdef HAVE_PSI_INTERFACE
 static PSI_mutex_key key_MDL_wait_LOCK_wait_status;
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -76,6 +76,7 @@
 #ifdef WITH_WSREP
 #include "wsrep_thd.h"
 #include "wsrep_sst.h"
+#include "wsrep_server_state.h"
 #endif /* WITH_WSREP */
 #include "proxy_protocol.h"
 

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -47,6 +47,7 @@
 #include "sql_audit.h"
 #include "debug_sync.h"
 #ifdef WITH_WSREP
+#include "wsrep.h"
 #include "wsrep_trans_observer.h"
 #endif /* WITH_WSREP */
 

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -56,6 +56,9 @@
 #include "password.h"
 
 #include "sql_plugin_compat.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 #define MAX_SCRAMBLE_LENGTH 1024
 

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -347,6 +347,9 @@ TODO list:
 #include "probes_mysql.h"
 #include "transaction.h"
 #include "strfunc.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 const uchar *query_state_map;
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -67,6 +67,7 @@
 #ifdef WITH_WSREP
 #include "wsrep_thd.h"
 #include "wsrep_trans_observer.h"
+#include "wsrep_server_state.h"
 #else
 static inline bool wsrep_is_bf_aborted(THD* thd) { return false; }
 #endif /* WITH_WSREP */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -65,7 +65,8 @@ void set_thd_stage_info(void *thd,
 #include "my_apc.h"
 #include "rpl_gtid.h"
 
-#include "wsrep_mysqld.h"
+#include "wsrep.h"
+#include "wsrep_on.h"
 #ifdef WITH_WSREP
 #include <inttypes.h>
 /* wsrep-lib */
@@ -76,6 +77,11 @@ void set_thd_stage_info(void *thd,
 
 class Wsrep_applier_service;
 
+enum wsrep_consistency_check_mode {
+    NO_CONSISTENCY_CHECK,
+    CONSISTENCY_CHECK_DECLARED,
+    CONSISTENCY_CHECK_RUNNING,
+};
 #endif /* WITH_WSREP */
 class Reprepare_observer;
 class Relay_log_info;

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -37,6 +37,9 @@
 #include "sql_partition.h"
 #include "sql_partition_admin.h"               // Sql_cmd_alter_table_*_part
 #include "event_parse_data.h"
+#ifdef WITH_WSREP
+#include "mysql/service_wsrep.h"
+#endif
 
 void LEX::parse_error(uint err_number)
 {

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -32,6 +32,7 @@
 #include "ha_partition.h"                   // ha_partition
 #endif
 #include "sql_base.h"                       // open_and_lock_tables
+#include "wsrep_mysqld.h"
 
 #ifndef WITH_PARTITION_STORAGE_ENGINE
 

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -39,6 +39,7 @@
 #include <mysql/plugin_password_validation.h>
 #include <mysql/plugin_encryption.h>
 #include "sql_plugin_compat.h"
+#include "wsrep_mysqld.h"
 
 #ifdef HAVE_LINK_H
 #include <link.h>

--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -31,6 +31,9 @@
 #include "debug_sync.h"
 #include "des_key_file.h"
 #include "transaction.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 static void disable_checkpoints(THD *thd);
 

--- a/sql/sql_sequence.cc
+++ b/sql/sql_sequence.cc
@@ -25,6 +25,9 @@
 #include "transaction.h"
 #include "lock.h"
 #include "sql_acl.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 struct Field_definition
 {

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -55,6 +55,9 @@
 #include "sql_sequence.h"
 #include "tztime.h"
 #include <algorithm>
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 #ifdef __WIN__
 #include <io.h>

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -35,6 +35,9 @@
 #include "sp_cache.h"                     // sp_invalidate_cache
 #include <mysys_err.h>
 #include "debug_sync.h"
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 /*************************************************************************/
 

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -37,6 +37,7 @@
 #include "sql_derived.h"
 #include "sql_cte.h"    // check_dependencies_in_with_clauses()
 #include "opt_trace.h"
+#include "wsrep_mysqld.h"
 
 #define MD5_BUFF_LENGTH 33
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -66,6 +66,9 @@
 #include "semisync_master.h"
 #include "semisync_slave.h"
 #include <ssl_compat.h>
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
 
 /*
   The rule for this file: everything should be 'static'. When a sys_var

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -16,11 +16,11 @@
 #include "mariadb.h"
 #include "mysql/service_wsrep.h"
 #include "wsrep_binlog.h"
-#include "wsrep_priv.h"
 #include "log.h"
 #include "slave.h"
 #include "log_event.h"
 #include "wsrep_applier.h"
+#include "wsrep_mysqld.h"
 
 #include "transaction.h"
 

--- a/sql/wsrep_check_opts.cc
+++ b/sql/wsrep_check_opts.cc
@@ -19,6 +19,7 @@
 #include "sys_vars_shared.h"
 #include "wsrep.h"
 #include "wsrep_sst.h"
+#include "wsrep_mysqld.h"
 
 extern char *my_bind_addr_str;
 

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -21,6 +21,7 @@
 #include "wsrep_thd.h"
 #include "wsrep_xid.h"
 #include "wsrep_trans_observer.h"
+#include "wsrep_server_state.h"
 
 #include "sql_base.h"    /* close_temporary_table() */
 #include "sql_class.h"   /* THD */

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -19,6 +19,7 @@
 #include "wsrep_schema.h"
 #include "wsrep_xid.h"
 #include "wsrep_trans_observer.h"
+#include "wsrep_server_state.h"
 
 #include "sql_class.h" /* THD */
 #include "transaction.h"

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -19,8 +19,6 @@
 #include <wsrep.h>
 
 #ifdef WITH_WSREP
-extern bool WSREP_ON_;
-extern bool WSREP_PROVIDER_EXISTS_;
 
 #include <mysql/plugin.h>
 #include "mysql/service_wsrep.h"
@@ -39,19 +37,10 @@ typedef struct st_mysql_show_var SHOW_VAR;
 #include "wsrep/provider.hpp"
 #include "wsrep/streaming_context.hpp"
 #include "wsrep_api.h"
-#include <vector>
-#include "wsrep_server_state.h"
 
 #define WSREP_UNDEFINED_TRX_ID ULONGLONG_MAX
 
-class set_var;
 class THD;
-
-enum wsrep_consistency_check_mode {
-    NO_CONSISTENCY_CHECK,
-    CONSISTENCY_CHECK_DECLARED,
-    CONSISTENCY_CHECK_RUNNING,
-};
 
 // Global wsrep parameters
 
@@ -79,7 +68,6 @@ extern ulong       wsrep_max_ws_rows;
 extern const char* wsrep_notify_cmd;
 extern my_bool     wsrep_certify_nonPK;
 extern long int    wsrep_protocol_version;
-extern ulong       wsrep_forced_binlog_format;
 extern my_bool     wsrep_desync;
 extern ulong       wsrep_reject_queries;
 extern my_bool     wsrep_recovery;
@@ -217,67 +205,40 @@ extern bool wsrep_reload_ssl();
 
 /* Other global variables */
 extern wsrep_seqno_t wsrep_locked_seqno;
-#define WSREP_ON unlikely(WSREP_ON_)
-
-/* use xxxxxx_NNULL macros when thd pointer is guaranteed to be non-null to
- * avoid compiler warnings (GCC 6 and later) */
-
-#define WSREP_NNULL(thd) \
-  (WSREP_PROVIDER_EXISTS_ && thd->variables.wsrep_on)
-
-#define WSREP(thd) \
-  (thd && WSREP_NNULL(thd))
-
-#define WSREP_CLIENT_NNULL(thd) \
-  (WSREP_NNULL(thd) && thd->wsrep_client_thread)
-
-#define WSREP_CLIENT(thd) \
-    (WSREP(thd) && thd->wsrep_client_thread)
-
-#define WSREP_EMULATE_BINLOG_NNULL(thd) \
-  (WSREP_NNULL(thd) && wsrep_emulate_bin_log)
-
-#define WSREP_EMULATE_BINLOG(thd) \
-  (WSREP(thd) && wsrep_emulate_bin_log)
-
-#define WSREP_BINLOG_FORMAT(my_format)                         \
-   ((wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC) ?     \
-   wsrep_forced_binlog_format : my_format)
 
 /* A wrapper function for MySQL log functions. The call will prefix
    the log message with WSREP and forward the result buffer to fun. */
 void WSREP_LOG(void (*fun)(const char* fmt, ...), const char* fmt, ...);
 
-#define WSREP_DEBUG(...)                                                \
-    if (wsrep_debug)     WSREP_LOG(sql_print_information, ##__VA_ARGS__)
-#define WSREP_INFO(...)  WSREP_LOG(sql_print_information, ##__VA_ARGS__)
-#define WSREP_WARN(...)  WSREP_LOG(sql_print_warning,     ##__VA_ARGS__)
-#define WSREP_ERROR(...) WSREP_LOG(sql_print_error,       ##__VA_ARGS__)
-#define WSREP_UNKNOWN(fmt, ...) WSREP_ERROR("UNKNOWN: " fmt, ##__VA_ARGS__)
+#define WSREP_SYNC_WAIT(thd_, before_)                                  \
+    { if (WSREP_CLIENT(thd_) &&                                         \
+          wsrep_sync_wait(thd_, before_)) goto wsrep_error_label; }
 
-#define WSREP_LOG_CONFLICT_THD(thd, role)                               \
-  WSREP_INFO("%s: \n "                                                  \
-             "  THD: %lu, mode: %s, state: %s, conflict: %s, seqno: %lld\n " \
-             "  SQL: %s",                                               \
-             role,                                                      \
-             thd_get_thread_id(thd),                                    \
-             wsrep_thd_client_mode_str(thd),                            \
-             wsrep_thd_client_state_str(thd),                           \
-             wsrep_thd_transaction_state_str(thd),                      \
-             wsrep_thd_trx_seqno(thd),                                  \
-             wsrep_thd_query(thd)                                       \
-            );
+#define WSREP_MYSQL_DB (char *)"mysql"
 
-#define WSREP_LOG_CONFLICT(bf_thd, victim_thd, bf_abort)                \
-  if (wsrep_debug || wsrep_log_conflicts)                               \
-  {                                                                     \
-    WSREP_INFO("cluster conflict due to %s for threads:",               \
-               (bf_abort) ? "high priority abort" : "certification failure" \
-              );                                                        \
-    if (bf_thd)     WSREP_LOG_CONFLICT_THD(bf_thd, "Winning thread");   \
-    if (victim_thd) WSREP_LOG_CONFLICT_THD(victim_thd, "Victim thread"); \
-    WSREP_INFO("context: %s:%d", __FILE__, __LINE__); \
-  }
+#define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_)              \
+  if (WSREP_ON && WSREP(thd) && wsrep_to_isolation_begin(thd, db_, table_, table_list_)) \
+    goto wsrep_error_label;
+
+#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_, fk_tables_) \
+  if (WSREP(thd) && wsrep_thd_is_local(thd) &&                          \
+      wsrep_to_isolation_begin(thd, db_, table_,                        \
+                               table_list_, alter_info_, fk_tables_))
+
+#define WSREP_TO_ISOLATION_END                                          \
+  if ((WSREP(thd) && wsrep_thd_is_local_toi(thd)) ||                    \
+      wsrep_thd_is_in_rsu(thd))                                         \
+    wsrep_to_isolation_end(thd);
+
+/*
+  Checks if lex->no_write_to_binlog is set for statements that use LOCAL or
+  NO_WRITE_TO_BINLOG.
+*/
+#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)       \
+  if (WSREP(thd) && !thd->lex->no_write_to_binlog                       \
+      && wsrep_to_isolation_begin(thd, db_, table_, table_list_))       \
+    goto wsrep_error_label;
+
 
 #define WSREP_PROVIDER_EXISTS (WSREP_PROVIDER_EXISTS_)
 
@@ -290,9 +251,6 @@ static inline bool wsrep_cluster_address_exists()
 
 extern my_bool wsrep_ready_get();
 extern void wsrep_ready_wait();
-
-class Ha_trx_info;
-struct THD_TRANS;
 
 extern mysql_mutex_t LOCK_wsrep_ready;
 extern mysql_cond_t  COND_wsrep_ready;
@@ -316,7 +274,6 @@ extern mysql_mutex_t LOCK_wsrep_donor_monitor;
 extern mysql_cond_t  COND_wsrep_joiner_monitor;
 extern mysql_cond_t  COND_wsrep_donor_monitor;
 
-extern my_bool       wsrep_emulate_bin_log;
 extern int           wsrep_to_isolation;
 #ifdef GTID_SUPPORT
 extern rpl_sidno     wsrep_sidno;
@@ -488,12 +445,6 @@ wsrep::key wsrep_prepare_key_for_toi(const char* db, const char* table,
 /* These macros are needed to compile MariaDB without WSREP support
  * (e.g. embedded) */
 
-#define WSREP_ON false
-#define WSREP(T)  (0)
-#define WSREP_NNULL(T) (0)
-#define WSREP_EMULATE_BINLOG(thd) (0)
-#define WSREP_EMULATE_BINLOG_NNULL(thd) (0)
-#define WSREP_BINLOG_FORMAT(my_format) ((ulong)my_format)
 #define WSREP_PROVIDER_EXISTS (0)
 #define wsrep_emulate_bin_log (0)
 #define wsrep_to_isolation (0)
@@ -505,6 +456,12 @@ wsrep::key wsrep_prepare_key_for_toi(const char* db, const char* table,
 #define wsrep_init_globals() do {} while(0)
 #define wsrep_create_appliers(X) do {} while(0)
 #define wsrep_cluster_address_exists() (false)
+#define WSREP_MYSQL_DB (0)
+#define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_) do { } while(0)
+#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_, fk_tables_)
+#define WSREP_TO_ISOLATION_END
+#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)
+#define WSREP_SYNC_WAIT(thd_, before_)
 
 #endif /* WITH_WSREP */
 

--- a/sql/wsrep_on.h
+++ b/sql/wsrep_on.h
@@ -1,0 +1,63 @@
+/* Copyright 2022 Codership Oy <http://www.codership.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111-1301 USA */
+
+#ifndef WSREP_ON_H
+#define WSREP_ON_H
+
+#ifdef WITH_WSREP
+
+extern bool WSREP_ON_;
+extern bool WSREP_PROVIDER_EXISTS_;
+extern my_bool wsrep_emulate_bin_log;
+extern ulong wsrep_forced_binlog_format;
+
+#define WSREP_ON unlikely(WSREP_ON_)
+
+/* use xxxxxx_NNULL macros when thd pointer is guaranteed to be non-null to
+ * avoid compiler warnings (GCC 6 and later) */
+
+#define WSREP_NNULL(thd) \
+  (WSREP_PROVIDER_EXISTS_ && thd->variables.wsrep_on)
+
+#define WSREP(thd) \
+  (thd && WSREP_NNULL(thd))
+
+#define WSREP_CLIENT_NNULL(thd) \
+  (WSREP_NNULL(thd) && thd->wsrep_client_thread)
+
+#define WSREP_CLIENT(thd) \
+    (WSREP(thd) && thd->wsrep_client_thread)
+
+#define WSREP_EMULATE_BINLOG_NNULL(thd) \
+  (WSREP_NNULL(thd) && wsrep_emulate_bin_log)
+
+#define WSREP_EMULATE_BINLOG(thd) \
+  (WSREP(thd) && wsrep_emulate_bin_log)
+
+#define WSREP_BINLOG_FORMAT(my_format) \
+   ((wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC) ? \
+   wsrep_forced_binlog_format : my_format)
+
+#else
+
+#define WSREP_ON false
+#define WSREP(T)  (0)
+#define WSREP_NNULL(T) (0)
+#define WSREP_EMULATE_BINLOG(thd) (0)
+#define WSREP_EMULATE_BINLOG_NNULL(thd) (0)
+#define WSREP_BINLOG_FORMAT(my_format) ((ulong)my_format)
+
+#endif
+#endif

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -19,13 +19,8 @@
 #ifndef WSREP_PRIV_H
 #define WSREP_PRIV_H
 
-#include <my_global.h>
-#include "wsrep_mysqld.h"
-#include "wsrep_schema.h"
-
-#include <log.h>
-#include <pthread.h>
-#include <cstdio>
+#include "wsrep_api.h"
+#include "wsrep/server_state.hpp"
 
 my_bool wsrep_ready_set (my_bool x);
 
@@ -39,7 +34,6 @@ wsrep_cb_status wsrep_sst_donate_cb (void* app_ctx,
 
 extern wsrep_uuid_t  local_uuid;
 extern wsrep_seqno_t local_seqno;
-extern Wsrep_schema* wsrep_schema;
 
 // a helper function
 bool wsrep_sst_received(THD*, const wsrep_uuid_t&, wsrep_seqno_t,

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -30,6 +30,7 @@
 #include "wsrep_high_priority_service.h"
 #include "wsrep_storage_service.h"
 #include "wsrep_thd.h"
+#include "wsrep_server_state.h"
 
 #include <string>
 #include <sstream>

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -29,6 +29,7 @@
 #include "wsrep_utils.h"
 #include "wsrep_xid.h"
 #include "wsrep_thd.h"
+#include "wsrep_server_state.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -18,6 +18,7 @@
 #include "wsrep_trans_observer.h"
 #include "wsrep_high_priority_service.h"
 #include "wsrep_storage_service.h"
+#include "wsrep_server_state.cc"
 #include "transaction.h"
 #include "rpl_rli.h"
 #include "log_event.h"

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include "wsrep_trans_observer.h"
+#include "wsrep_server_state.h"
 
 ulong   wsrep_reject_queries;
 

--- a/storage/innobase/dict/dict0stats_bg.cc
+++ b/storage/innobase/dict/dict0stats_bg.cc
@@ -36,7 +36,6 @@ Created Apr 25, 2012 Vasil Dimov
 # include "mysql/service_wsrep.h"
 # include "wsrep.h"
 # include "log.h"
-# include "wsrep_mysqld.h"
 #endif
 
 #include <vector>

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -573,9 +573,6 @@ bool thd_is_strict_mode(const MYSQL_THD thd);
 extern void mysql_bin_log_commit_pos(THD *thd, ulonglong *out_pos, const char **out_file);
 
 struct trx_t;
-#ifdef WITH_WSREP
-#include <mysql/service_wsrep.h>
-#endif /* WITH_WSREP */
 
 extern const struct _ft_vft ft_vft_result;
 

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -45,7 +45,8 @@ Created 4/20/1996 Heikki Tuuri
 #include "fts0fts.h"
 #include "fts0types.h"
 #ifdef WITH_WSREP
-#include "wsrep_mysqld.h"
+#include <wsrep.h>
+#include <mysql/service_wsrep.h>
 #endif /* WITH_WSREP */
 
 /*************************************************************************

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -70,12 +70,6 @@ Created 9/17/2000 Heikki Tuuri
 #include <deque>
 #include <vector>
 
-#ifdef WITH_WSREP
-#include "mysql/service_wsrep.h"
-#include "wsrep.h"
-#include "log.h"
-#include "wsrep_mysqld.h"
-#endif
 
 /** Provide optional 4.x backwards compatibility for 5.0 and above */
 ibool	row_rollback_on_timeout	= FALSE;


### PR DESCRIPTION
Making changes to wsrep_mysqld.h causes large parts of server code to
be recompiled. The reason is that wsrep_mysqld.h is included by
sql_class.h, even tough very little of wsrep_mysqld.h is needed in
sql_class.h. This commit introduces a new header file, wsrep_on.h,
which is meant to be included from sql_class.h, and contains only
macros and variable declarations used to determine whether wsrep is
enabled.
Also, header wsrep.h should only contain definitions that are also
used outside of sql/. Therefore, move WSREP_TO_ISOLATION* and
WSREP_SYNC_WAIT macros to wsrep_mysqld.h.