### PR TITLE
MDEV-26575 Crash on shutdown after starting an XA transaction

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-26575.result
+++ b/mysql-test/suite/galera/r/MDEV-26575.result
@@ -1,0 +1,6 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET SESSION wsrep_on = OFF;
+XA START 'xatest';
+ERROR 42000: This version of MariaDB doesn't yet support 'XA transactions with Galera replication'

--- a/mysql-test/suite/galera/t/MDEV-26575.test
+++ b/mysql-test/suite/galera/t/MDEV-26575.test
@@ -1,0 +1,12 @@
+#
+# MDEV-26575 Server crashes when execute shutdown statement after
+# starting an XA transaction
+#
+
+--source include/galera_cluster.inc
+
+--connection node_2
+SET SESSION wsrep_on = OFF;
+--error ER_NOT_SUPPORTED_YET
+XA START 'xatest';
+--source include/restart_mysqld.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6047,7 +6047,7 @@ mysql_execute_command(THD *thd)
   }
   case SQLCOM_XA_START:
 #ifdef WITH_WSREP
-    if (WSREP(thd))
+    if (WSREP_ON)
     {
       my_error(ER_NOT_SUPPORTED_YET, MYF(0),
                "XA transactions with Galera replication");


### PR DESCRIPTION
Reason for the crash is that ongoing XA transactions are not properly
BF aborted when the server is shutdown.
Use trans_xa_detach() instead of trans_rollback() for XA transactions
in Wsrep_client_service::bf_rollback().
