### PR TITLE
MDEV-25912 wsrep does not identify  checksummed events correctly

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -5841,6 +5841,8 @@ THD::binlog_start_trans_and_stmt()
         }
         Gtid_log_event gtid_event(this, seqno, domain_id, true,
                                   LOG_EVENT_SUPPRESS_USE_F, true, 0);
+        // Replicated events in writeset doesn't have checksum
+        gtid_event.checksum_alg= BINLOG_CHECKSUM_ALG_OFF;
         gtid_event.server_id= server_id;
         writer.write(&gtid_event);
         wsrep_write_cache_buf(&tmp_io_cache, &buf, &len);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2624,11 +2624,6 @@ Gtid_log_event::Gtid_log_event(const uchar *buf, uint event_len,
   */
   DBUG_ASSERT(static_cast<uint>(buf - buf_0) <= event_len);
   /* and the last of them is tested. */
-#ifdef MYSQL_SERVER
-#ifdef WITH_WSREP
-  if (!WSREP_ON)
-#endif
-#endif
   DBUG_ASSERT(static_cast<uint>(buf - buf_0) == event_len ||
               buf_0[event_len - 1] == 0);
 }


### PR DESCRIPTION
For GTID consistenty, GTID events was artificialy added before
replication happned. This event should not contain CHECKSUM calculated.