### PR TITLE
MDEV-29684 Fixes for cluster wide write  conflict resolving

### DIFF
--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -349,13 +349,20 @@ extern "C" void wsrep_commit_ordered(THD *thd)
 
 extern "C" bool wsrep_thd_set_wsrep_aborter(THD *bf_thd, THD *victim_thd)
 {
-  WSREP_DEBUG("wsrep_thd_set_wsrep_aborter called");
   mysql_mutex_assert_owner(&victim_thd->LOCK_thd_data);
+  if (!bf_thd)
+  {
+    victim_thd->wsrep_aborter= 0;
+    WSREP_DEBUG("wsrep_thd_set_wsrep_aborter resetting wsrep_aborter");
+    return false;
+  }
   if (victim_thd->wsrep_aborter && victim_thd->wsrep_aborter != bf_thd->thread_id)
   {
     return true;
   }
-  victim_thd->wsrep_aborter = bf_thd->thread_id;
+  victim_thd->wsrep_aborter= bf_thd->thread_id;
+  WSREP_DEBUG("wsrep_thd_set_wsrep_aborter setting wsrep_aborter %u",
+              victim_thd->wsrep_aborter);
   return false;
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18711,6 +18711,13 @@ wsrep_kill_victim(
       victim_trx->lock.was_chosen_as_deadlock_victim= TRUE;
       lock_cancel_waiting_and_release(wait_lock);
     }
+  } else {
+    wsrep_thd_LOCK(thd);
+    victim_trx->lock.was_chosen_as_wsrep_victim= false;
+    wsrep_thd_set_wsrep_aborter(NULL, thd);
+    wsrep_thd_UNLOCK(thd);
+
+    WSREP_DEBUG("wsrep_thd_bf_abort has failed, victim will survive");
   }
 
   DBUG_VOID_RETURN;


### PR DESCRIPTION
Cluster conflict victim's THD is marked with wsrep_aborter. THD::wsrep_aorter holds the thread ID of the hight priority tread, which is currently carrying out BF aborting for this victim.

However, the BF abort operation is not always successful, and in such case the wsrep_aboter mark should be removed. In the old code, this wsrep_aborter resetting did not happen, and this could lead to a situation where the sticky wsrep_aborter mark prevents any further attempt to BF abort this transaction.

This commit fixes this issue, and resets wsrep_aborter after unsuccesful BF abort attempt.