### PR TITLE
10.4-MDEV-29684 Fixes for cluster wide write conflict resolving

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5229,7 +5229,8 @@ thd_need_ordering_with(const MYSQL_THD thd, const MYSQL_THD other_thd)
   */
   if (WSREP_ON &&
       wsrep_thd_is_BF(const_cast<THD *>(thd), false) &&
-      wsrep_thd_is_BF(const_cast<THD *>(other_thd), false))
+      wsrep_thd_is_BF(const_cast<THD *>(other_thd), false) &&
+      wsrep_thd_order_before(const_cast<THD *>(thd), const_cast<THD *>(other_thd)))
     return 0;
 #endif /* WITH_WSREP */
   rgi= thd->rgi_slave;


### PR DESCRIPTION
The rather recent thd_need_ordering_with() function does not take high priority transactions' order in consideration. Chaged this funtion to compare also transaction seqnos and favor earlier transaction.