### PR TITLE
Reenable test galera_sr_kill_slave_after_apply_rollback2

### DIFF
--- a/mysql-test/suite/galera_3nodes_sr/disabled.def
+++ b/mysql-test/suite/galera_3nodes_sr/disabled.def
@@ -3,4 +3,3 @@ GCF-582 :
 GCF-810A : 
 GCF-810B : 
 GCF-810C : 
-galera_sr_kill_slave_after_apply_rollback2 :

--- a/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_after_apply_rollback2.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_after_apply_rollback2.result
@@ -1,26 +1,23 @@
-SET SESSION wsrep_trx_fragment_size = 1;
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
+connection node_2;
+connection node_1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
+connection node_2;
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 Killing server ...
+connection node_1;
 INSERT INTO t1 VALUES (6);
 ROLLBACK;
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-COUNT(*) = 0
-1
-SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
-COUNT(*) = 0
-1
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-COUNT(*) = 0
-1
+connection node_2;
+# restart
+connection node_2;
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_after_apply_rollback2.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_after_apply_rollback2.test
@@ -9,12 +9,11 @@
 
 --connection node_1
 
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
 --let $wsrep_trx_fragment_size_orig = `SELECT @@wsrep_trx_fragment_size`
 SET SESSION wsrep_trx_fragment_size = 1;
-SET AUTOCOMMIT=OFF;
 START TRANSACTION;
-
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
@@ -25,30 +24,24 @@ INSERT INTO t1 VALUES (5);
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 --let $wait_condition = SELECT COUNT(*) > 0 FROM t1;
 --source include/wait_condition.inc
-
 --source include/kill_galera.inc
---sleep 1
 
 --connection node_1
 INSERT INTO t1 VALUES (6);
 ROLLBACK;
 
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 --connection node_2
 --source include/start_mysqld.inc
---sleep 1
-
 --source include/wait_until_connected_again.inc
 --source include/galera_wait_ready.inc
 
 --connection node_2
-
---connection node_2
-SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 SELECT COUNT(*) = 0 FROM t1;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;


### PR DESCRIPTION
Remove unnecessary --sleep commands from the test. Add a wait condition to make sure node is killed before restarting it.