### PR TITLE
MDEV-29171 changing the value of wsrep_gtid_domain_id with full

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/MDEV-29171.result
+++ b/mysql-test/suite/galera_3nodes/r/MDEV-29171.result
@@ -1,0 +1,41 @@
+connection node_2;
+connection node_1;
+connection node_1;
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+@@wsrep_gtid_domain_id	@@wsrep_node_name
+100	node1
+connection node_2;
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+@@wsrep_gtid_domain_id	@@wsrep_node_name
+100	node2
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_3;
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+@@wsrep_gtid_domain_id	@@wsrep_node_name
+100	node3
+connection node_3;
+connection node_2;
+connection node_1;
+connection node_1;
+# restart: --wsrep_new_cluster --wsrep_gtid_domain_id=200
+show variables like 'wsrep_gtid_domain_id';
+Variable_name	Value
+wsrep_gtid_domain_id	200
+connection node_2;
+# restart
+show variables like 'wsrep_gtid_domain_id';
+Variable_name	Value
+wsrep_gtid_domain_id	200
+connection node_3;
+# restart: --wsrep_sst_donor=node2
+show variables like 'wsrep_gtid_domain_id';
+Variable_name	Value
+wsrep_gtid_domain_id	200
+connection node_1;
+set global wsrep_gtid_domain_id=100;
+connection node_2;
+set global wsrep_gtid_domain_id=100;
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+connection node_3;
+set global wsrep_gtid_domain_id=100;
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");

--- a/mysql-test/suite/galera_3nodes/t/MDEV-29171.cnf
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-29171.cnf
@@ -1,0 +1,14 @@
+!include ../galera_3nodes.cnf
+
+[mysqld.1]
+wsrep-node-name="node1"
+wsrep-gtid-mode=ON
+wsrep-gtid-domain-id=100
+
+[mysqld.2]
+wsrep-node-name="node2"
+wsrep-gtid-mode=ON
+
+[mysqld.3]
+wsrep-node-name="node3"
+wsrep-gtid-mode=ON

--- a/mysql-test/suite/galera_3nodes/t/MDEV-29171.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-29171.test
@@ -1,0 +1,83 @@
+#
+# MDEV-29171: changing the value of wsrep_gtid_domain_id
+# with full cluster restart fails on some nodes
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+#
+# Initially wsrep gtid domain id is 100
+#
+--connection node_1
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+
+--connection node_2
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
+select @@wsrep_gtid_domain_id,@@wsrep_node_name;
+
+
+#
+# Shutdown all nodes
+#
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+--source include/shutdown_mysqld.inc
+
+
+#
+# Bootstrap from node_1 and change wsrep_gtid_domain_id to 200
+#
+--connection node_1
+--let $restart_parameters = --wsrep_new_cluster --wsrep_gtid_domain_id=200
+--source include/start_mysqld.inc
+show variables like 'wsrep_gtid_domain_id';
+
+
+#
+# Restart node_2, expect that wsrep_gtid_domain_id has changed to 200
+#
+--connection node_2
+--let $restart_parameters = 
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+show variables like 'wsrep_gtid_domain_id';
+
+
+#
+# Restart node_3, select node_2 as donor
+# If bug is present, node_3 remains on domain id 100
+#
+--connection node_3
+--let $restart_parameters = --wsrep_sst_donor="node2"
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
+--source include/start_mysqld.inc
+# Expect domain id 200
+show variables like 'wsrep_gtid_domain_id';
+
+
+#
+# Cleanup
+#
+--connection node_1
+set global wsrep_gtid_domain_id=100;
+
+--connection node_2
+set global wsrep_gtid_domain_id=100;
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+
+--connection node_3
+set global wsrep_gtid_domain_id=100;
+CALL mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -364,10 +364,12 @@ static void wsrep_log_cb(wsrep::log::level level,
 void wsrep_init_gtid()
 {
   wsrep_server_gtid_t stored_gtid= wsrep_get_SE_checkpoint<wsrep_server_gtid_t>();
+  // Domain id may have changed, use the one
+  // received during state transfer.
+  stored_gtid.domain_id= wsrep_gtid_server.domain_id;
   if (stored_gtid.server_id == 0)
   {
     rpl_gtid wsrep_last_gtid;
-    stored_gtid.domain_id= wsrep_gtid_server.domain_id;
     if (mysql_bin_log.is_open() &&
         mysql_bin_log.lookup_domain_in_binlog_state(stored_gtid.domain_id,
                                                     &wsrep_last_gtid))


### PR DESCRIPTION
cluster restart fails on some nodes

Fix `wsrep_init_gtid()` to avoid overwriting the domain id received during state transfer.