### PR TITLE
MDEV-30383 Assertion `m_thd == _current_thd()'

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-30838.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-30838.result
@@ -1,0 +1,15 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+INSERT INTO t1 VALUES(1);
+SET debug_dbug='+d,ib_create_table_fail_too_many_trx';
+INSERT INTO t1 VALUES(2);
+ERROR HY000: Error while appending streaming replication fragment
+COMMIT;
+SELECT * FROM t1;
+f1
+SET debug_dbug='-d,ib_create_table_fail_too_many_trx';
+DROP TABLE t1;
+CALL mtr.add_suppression("Error writing into mysql.wsrep_streaming_log: 177");

--- a/mysql-test/suite/galera_sr/t/MDEV-30838.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-30838.test
@@ -1,0 +1,18 @@
+#
+# MDEV-30838 - Assertion `m_thd == _current_thd()' failed in
+# virtual int Wsrep_client_service::bf_rollback()
+#
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+INSERT INTO t1 VALUES(1);
+SET debug_dbug='+d,ib_create_table_fail_too_many_trx';
+--error ER_ERROR_DURING_COMMIT
+INSERT INTO t1 VALUES(2);
+COMMIT;
+SELECT * FROM t1;
+SET debug_dbug='-d,ib_create_table_fail_too_many_trx';
+DROP TABLE t1;
+CALL mtr.add_suppression("Error writing into mysql.wsrep_streaming_log: 177");

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -991,10 +991,9 @@ int Wsrep_schema::append_fragment(THD* thd,
   Wsrep_schema_impl::store(frag_table, 3, flags);
   Wsrep_schema_impl::store(frag_table, 4, data.data(), data.size());
 
-  int error;
-  if ((error= Wsrep_schema_impl::insert(frag_table))) {
-    WSREP_ERROR("Failed to write to frag table: %d", error);
+  if (Wsrep_schema_impl::insert(frag_table)) {
     trans_rollback_stmt(thd);
+    close_thread_tables(thd);
     thd->lex->restore_backup_query_tables_list(&query_tables_list_backup);
     DBUG_RETURN(1);
   }

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -228,7 +228,14 @@ static inline void wsrep_override_error(THD* thd,
       break;
     case wsrep::e_append_fragment_error:
       /* TODO: Figure out better error number */
-      wsrep_override_error(thd, ER_ERROR_DURING_COMMIT, 0, status);
+      if (status)
+        wsrep_override_error(thd, ER_ERROR_DURING_COMMIT,
+                             "Error while appending streaming replication fragment"
+                             "(provider status: %s)",
+                             wsrep::provider::to_string(status).c_str());
+      else
+        wsrep_override_error(thd, ER_ERROR_DURING_COMMIT,
+                             "Error while appending streaming replication fragment");
       break;
     case wsrep::e_not_supported_error:
       wsrep_override_error(thd, ER_NOT_SUPPORTED_YET);


### PR DESCRIPTION
- Update wsrep-lib which contains fix for the assertion
- Fix error handling for appending fragment to streaming log, make sure tables are closed after rollback.