### PR TITLE
MDEV-26175 : Assertion `! thd->in_sub_stmt' failed in bool trans_roll…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-26175.result
+++ b/mysql-test/suite/galera/r/mdev-26175.result
@@ -1,0 +1,32 @@
+connection node_2;
+connection node_1;
+connection node_1;
+SET sql_mode="no_zero_date";
+SET GLOBAL wsrep_max_ws_rows=1;
+CREATE TABLE t2 (a INT);
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+CREATE TRIGGER tgr BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (0);
+CREATE TABLE ti (id BIGINT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO ti VALUES (1);
+INSERT INTO t1 VALUES (0),(1);
+ERROR HY000: wsrep_max_ws_rows exceeded
+SELECT * FROM t1;
+a
+SELECT * FROM ti;
+id
+1
+SELECT * FROM t2;
+a
+connection node_2;
+SELECT * FROM t1;
+a
+SELECT * FROM ti;
+id
+1
+SELECT * FROM t2;
+a
+connection node_1;
+SET sql_mode=DEFAULT;
+SET GLOBAL wsrep_max_ws_rows=DEFAULT;
+DROP TRIGGER tgr;
+DROP TABLE t1, ti, t2;

--- a/mysql-test/suite/galera/t/mdev-26175.test
+++ b/mysql-test/suite/galera/t/mdev-26175.test
@@ -1,0 +1,29 @@
+--source include/galera_cluster.inc
+
+#
+# MDEV-26175 : Assertion `! thd->in_sub_stmt' failed in bool trans_rollback_stmt(THD*)
+#
+--connection node_1
+SET sql_mode="no_zero_date";
+SET GLOBAL wsrep_max_ws_rows=1;
+CREATE TABLE t2 (a INT);
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+CREATE TRIGGER tgr BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (0);
+CREATE TABLE ti (id BIGINT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO ti VALUES (1);
+--error ER_ERROR_DURING_COMMIT
+INSERT INTO t1 VALUES (0),(1);
+SELECT * FROM t1;
+SELECT * FROM ti;
+SELECT * FROM t2;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT * FROM ti;
+SELECT * FROM t2;
+
+--connection node_1
+SET sql_mode=DEFAULT;
+SET GLOBAL wsrep_max_ws_rows=DEFAULT;
+DROP TRIGGER tgr;
+DROP TABLE t1, ti, t2;


### PR DESCRIPTION
…back_stmt(THD*)

If we are inside stored function or trigger we should not commit or rollback current statement transaction.