### PR TITLE
MDEV-30456 ALTER TABLE algorithm clause not replicated

### DIFF
--- a/mysql-test/suite/galera/r/galera_alter_table_algorithm.result
+++ b/mysql-test/suite/galera/r/galera_alter_table_algorithm.result
@@ -1,0 +1,64 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_2;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_1;
+ALTER TABLE t1 ADD COLUMN f2 INTEGER, ALGORITHM=INSTANT;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	489	use `test`; ALTER TABLE t1 ADD COLUMN f2 INTEGER, ALGORITHM=INSTANT
+connection node_2;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	489	use `test`; ALTER TABLE t1 ADD COLUMN f2 INTEGER, ALGORITHM=INSTANT
+connection node_1;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_2;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_1;
+SET SESSION alter_algorithm='INSTANT';
+ALTER TABLE t1 ADD COLUMN f3 INTEGER;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	470	use `test`; ALTER TABLE t1 ADD COLUMN f3 INTEGER
+connection node_2;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	489	use `test`; ALTER TABLE t1 ADD COLUMN f3 INTEGER ,ALGORITHM=INSTANT
+connection node_1;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_2;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_1;
+SET SESSION alter_algorithm='INSTANT';
+ALTER TABLE t1 ADD COLUMN f4 INTEGER, ALGORITHM=COPY;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	486	use `test`; ALTER TABLE t1 ADD COLUMN f4 INTEGER, ALGORITHM=COPY
+connection node_2;
+show binlog events limit 1 offset 4;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	367	Query	1	486	use `test`; ALTER TABLE t1 ADD COLUMN f4 INTEGER, ALGORITHM=COPY
+connection node_1;
+DROP TABLE t1;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+connection node_2;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;

--- a/mysql-test/suite/galera/t/galera_alter_table_algorithm.cnf
+++ b/mysql-test/suite/galera/t/galera_alter_table_algorithm.cnf
@@ -1,0 +1,10 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+log_slave_updates=ON
+log_bin=binlog
+
+[mysqld.2]
+log_slave_updates=ON
+log_bin=binlog
+

--- a/mysql-test/suite/galera/t/galera_alter_table_algorithm.test
+++ b/mysql-test/suite/galera/t/galera_alter_table_algorithm.test
@@ -1,0 +1,82 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+#
+# Test 
+#
+
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB; 
+
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_2
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_1
+ALTER TABLE t1 ADD COLUMN f2 INTEGER, ALGORITHM=INSTANT;
+show binlog events limit 1 offset 4;
+
+--connection node_2
+show binlog events limit 1 offset 4;
+
+
+# Phase 2, setting algorithm before alter statement
+
+--connection node_1
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_2
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_1
+SET SESSION alter_algorithm='INSTANT';
+ALTER TABLE t1 ADD COLUMN f3 INTEGER;
+show binlog events limit 1 offset 4;
+
+--connection node_2
+show binlog events limit 1 offset 4;
+
+
+# Phase 3, setting different algorithm before alter statement
+
+--connection node_1
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_2
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_1
+SET SESSION alter_algorithm='INSTANT';
+ALTER TABLE t1 ADD COLUMN f4 INTEGER, ALGORITHM=COPY;
+show binlog events limit 1 offset 4;
+
+--connection node_2
+show binlog events limit 1 offset 4;
+
+
+#Cleanup
+
+--connection node_1
+DROP TABLE t1;
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+--connection node_2
+set global wsrep_on=OFF;
+reset master;
+set global wsrep_on=ON;
+
+

--- a/sql/sql_alter.h
+++ b/sql/sql_alter.h
@@ -108,6 +108,12 @@ public:
   // Number of partitions.
   uint                          num_parts;
 private:
+#ifdef WITH_WSREP
+  /* wsrep patch needs to peak the algorithm clause used in ALTER statement
+     in order to see if ALTER statement needs to be rewritten for replication
+  */
+public:
+#endif /* WITH_WSREP */
   // Type of ALTER TABLE algorithm.
   enum_alter_table_algorithm    requested_algorithm;
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1712,34 +1712,51 @@ int wsrep_to_buf_helper(
   return ret;
 }
 
-static int
-wsrep_alter_query_string(THD *thd, String *buf)
-{
-  /* Append the "ALTER" part of the query */
-  if (buf->append(STRING_WITH_LEN("ALTER ")))
-    return 1;
-  /* Append definer */
-  append_definer(thd, buf, &(thd->lex->definer->user), &(thd->lex->definer->host));
-  /* Append the left part of thd->query after event name part */
-  if (buf->append(thd->lex->stmt_definition_begin,
-                  thd->lex->stmt_definition_end -
-                  thd->lex->stmt_definition_begin))
-    return 1;
-
-  return 0;
-}
-
 static int wsrep_alter_event_query(THD *thd, uchar** buf, size_t* buf_len)
 {
   String log_query;
 
-  if (wsrep_alter_query_string(thd, &log_query))
+  /* build the  ALTER statement, with definer */
+  if (log_query.append(STRING_WITH_LEN("ALTER "))
+      || append_definer(thd, &log_query, &(thd->lex->definer->user), &(thd->lex->definer->host))
+      || log_query.append(thd->lex->stmt_definition_begin,
+                           thd->lex->stmt_definition_end -
+                           thd->lex->stmt_definition_begin))
   {
     WSREP_WARN("events alter string failed: schema: %s, query: %s",
                thd->get_db(), thd->query());
     return 1;
   }
-  return wsrep_to_buf_helper(thd, log_query.ptr(), log_query.length(), buf, buf_len);
+
+  return wsrep_to_buf_helper(thd, log_query.ptr(), log_query.length(),
+                             buf, buf_len);
+}
+
+static int wsrep_alter_table_query(THD *thd, uchar** buf, size_t* buf_len,
+                                   Alter_info *alter_info)
+{
+  String log_query;
+  log_query.append(thd->query());
+
+  /*
+     if user has specified the alter algorithm by session variable alter_algorithm
+     and the ALTER statement does not contain ALGORITHM= clause, then
+     build for replication new ALTER query with the ALGORITHM clause
+   */
+  if (thd->variables.alter_algorithm  != Alter_info::ALTER_TABLE_ALGORITHM_DEFAULT &&
+      alter_info->requested_algorithm == Alter_info::ALTER_TABLE_ALGORITHM_NONE)
+  {
+    if (log_query.append(" ,") ||
+        log_query.append(alter_info->algorithm_clause(thd)))
+    {
+      WSREP_WARN("alter table string failed: schema: %s, query: %s",
+                 thd->get_db(), thd->query());
+      return 1;
+    }
+  }
+
+  return wsrep_to_buf_helper(thd, log_query.ptr(), log_query.length(),
+                             buf, buf_len);
 }
 
 #include "sql_show.h"
@@ -2029,7 +2046,7 @@ static int wsrep_create_sp(THD *thd, uchar** buf, size_t* buf_len)
   return wsrep_to_buf_helper(thd, log_query.ptr(), log_query.length(), buf, buf_len);
 }
 
-static int wsrep_TOI_event_buf(THD* thd, uchar** buf, size_t* buf_len)
+static int wsrep_TOI_event_buf(THD* thd, uchar** buf, size_t* buf_len, Alter_info *alter_info)
 {
   int err;
   switch (thd->lex->sql_command)
@@ -2049,6 +2066,9 @@ static int wsrep_TOI_event_buf(THD* thd, uchar** buf, size_t* buf_len)
     break;
   case SQLCOM_ALTER_EVENT:
     err= wsrep_alter_event_query(thd, buf, buf_len);
+    break;
+  case SQLCOM_ALTER_TABLE:
+    err= wsrep_alter_table_query(thd, buf, buf_len, alter_info);
     break;
   case SQLCOM_DROP_TABLE:
     err= wsrep_drop_table_query(thd, buf, buf_len);
@@ -2122,7 +2142,7 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
   int buf_err;
   int rc;
 
-  buf_err= wsrep_TOI_event_buf(thd, &buf, &buf_len);
+  buf_err= wsrep_TOI_event_buf(thd, &buf, &buf_len, alter_info);
   if (buf_err) {
     WSREP_ERROR("Failed to create TOI event buf: %d", buf_err);
     my_message(ER_UNKNOWN_ERROR,


### PR DESCRIPTION
If user has specified the desired alter algorithm by using session variable alter_algorithm, and not specifying the algorithm in the ALTER SQL statement, then the ALTER will be processed in sending node according the algorithm chosen by alter_algorithm. But in receiving nodes, appliers cannot see this sessio variable, and will use the default algorithm when executing the ALTER.

The fix in this commit, will check if user has set alter_algorithm variable and has not specified the algorithm clause in the ALTER statement, and in such case will rewrite the original ALTER statement appended by the algorithm clause. This rewritten ALTER statement will be used in replication.