### PR TITLE
MDEV-28433 : Server crashes when wsrep_sst_donor and wsrep_cluster_ad…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-28433.result
+++ b/mysql-test/suite/galera/r/mdev-28433.result
@@ -1,0 +1,25 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_2;
+SET @@global.wsrep_sst_donor = NULL;
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of 'NULL'
+SET @@global.wsrep_cluster_address='NULL';
+SET SESSION wsrep_sync_wait=0;
+SELECT @@wsrep_sst_donor;
+@@wsrep_sst_donor
+
+SELECT @@wsrep_cluster_address;
+@@wsrep_cluster_address
+NULL
+SHOW STATUS LIKE 'wsrep_ready';
+Variable_name	Value
+wsrep_ready	OFF
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Disconnected
+call mtr.add_suppression("WSREP: .*Invalid backend URI.*");
+call mtr.add_suppression("WSREP: gcs connect failed: Invalid argument");
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/mdev-28433.test
+++ b/mysql-test/suite/galera/t/mdev-28433.test
@@ -1,0 +1,35 @@
+--source include/galera_cluster.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source include/auto_increment_offset_save.inc
+
+--connection node_2
+--let $wsrep_cluster_address_saved = `SELECT @@global.wsrep_cluster_address`
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_donor = NULL;
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+SET @@global.wsrep_cluster_address='NULL';
+SET SESSION wsrep_sync_wait=0;
+SELECT @@wsrep_sst_donor;
+SELECT @@wsrep_cluster_address;
+# Must return 'OFF'
+SHOW STATUS LIKE 'wsrep_ready';
+
+# Must return 'Disconnected'
+SHOW STATUS LIKE 'wsrep_cluster_status';
+
+--disable_query_log
+--eval SET @@global.wsrep_cluster_address = '$wsrep_cluster_address_orig'
+--enable_query_log
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+call mtr.add_suppression("WSREP: .*Invalid backend URI.*");
+call mtr.add_suppression("WSREP: gcs connect failed: Invalid argument");
+
+# Restore original auto_increment_offset values.
+--source include/auto_increment_offset_restore.inc
+
+--source include/galera_end.inc

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_donor_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_donor_basic.result
@@ -33,17 +33,22 @@ SET @@global.wsrep_sst_donor=default;
 SELECT @@global.wsrep_sst_donor;
 @@global.wsrep_sst_donor
 
-SET @@global.wsrep_sst_donor=NULL;
+SET @@global.wsrep_sst_donor='';
 SELECT @@global.wsrep_sst_donor;
 @@global.wsrep_sst_donor
-NULL
+
 
 # invalid values
 SET @@global.wsrep_sst_donor=1;
 ERROR 42000: Incorrect argument type to variable 'wsrep_sst_donor'
 SELECT @@global.wsrep_sst_donor;
 @@global.wsrep_sst_donor
-NULL
+
+SET @@global.wsrep_sst_donor=NULL;
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+
 
 # restore the initial value
 SET @@global.wsrep_sst_donor = @wsrep_sst_donor_global_saved;

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_donor_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_donor_basic.test
@@ -27,13 +27,16 @@ SET @@global.wsrep_sst_donor='hyphenated-donor-name';
 SELECT @@global.wsrep_sst_donor;
 SET @@global.wsrep_sst_donor=default;
 SELECT @@global.wsrep_sst_donor;
-SET @@global.wsrep_sst_donor=NULL;
+SET @@global.wsrep_sst_donor='';
 SELECT @@global.wsrep_sst_donor;
 
 --echo
 --echo # invalid values
 --error ER_WRONG_TYPE_FOR_VAR
 SET @@global.wsrep_sst_donor=1;
+SELECT @@global.wsrep_sst_donor;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_donor=NULL;
 SELECT @@global.wsrep_sst_donor;
 
 --echo

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -299,6 +299,15 @@ void wsrep_sst_auth_init ()
 
 bool  wsrep_sst_donor_check (sys_var *self, THD* thd, set_var* var)
 {
+  if ((! var->save_result.string_value.str) ||
+      (var->save_result.string_value.length > (FN_REFLEN -1))) // safety
+  {
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), var->var->name.str,
+             var->save_result.string_value.str ?
+             var->save_result.string_value.str : "NULL");
+    return 1;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
…dress set to NULL

Do not allow setting wsrep_sst_donor as NULL as it is incorrect value. User can use value '' (default) that represents same as NULL. Setting wsrep_cluster_address to NULL is already handled correctly.