### PR TITLE
10.6-MDEV-31272 statement rollback causing empty write set replication

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -11905,6 +11905,7 @@ void wsrep_thd_binlog_stmt_rollback(THD * thd)
   {
     thd->binlog_remove_pending_rows_event(TRUE, TRUE);
     cache_mngr->stmt_cache.reset();
+    cache_mngr->trx_cache.restore_prev_position();
   }
   DBUG_VOID_RETURN;
 }

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -101,7 +101,6 @@ int Wsrep_client_service::prepare_data_for_replication()
     {
       WSREP_ERROR("rbr write fail, data_len: %zu",
                   data_len);
-      // wsrep_override_error(m_thd, ER_ERROR_DURING_COMMIT);
       DBUG_RETURN(1);
     }
 
@@ -110,7 +109,6 @@ int Wsrep_client_service::prepare_data_for_replication()
     {
       WSREP_ERROR("rbr write fail, data_len: %zu",
                   data_len);
-      // wsrep_override_error(m_thd, ER_ERROR_DURING_COMMIT);
       DBUG_RETURN(1);
     }
 
@@ -138,6 +136,7 @@ int Wsrep_client_service::prepare_data_for_replication()
     {
       WSREP_DEBUG("empty rbr buffer, query: %s", wsrep_thd_query(m_thd));
     }
+    DBUG_RETURN(1);
   }
   DBUG_RETURN(0);
 }


### PR DESCRIPTION
If a statement execution has successfully modified some rows, then the write set for the transaction, will be appended by the key values related to the modified rows. If the staement execution eventually fails, e.g. for duplicate key error, then statement rollback will be carried out, to undo changes in storage engine and truncate binlog cache to wipe out replication events related to the statement execution.

If the transaction has no other successful write statements then there is nothing to commit, at commit time,  and no binlog events either. But as there were earlier key appends, the transaction remains registred for wsrep replication, and at commit time replicator extracts binlog events from cache and populates the final write set for the replication. In the buggy version, it was observed that there are no binlog events, but the write set was populated, nevertheless, and the empty write set was replicated.  Note that this consumes one GTID, for a void operation.

The fix for this issue, cancels the replication of such empty write set anf gives a warning for the client.
This fix is in: Wsrep_client_service::prepare_data_for_replication()

It also turned out that the binlog cache truncate for statement rollback was not complete if server was not configured to use binloggging. In buggy version, only statmenet cache was truncated, but events remained in the transaction cache. This has been fixed in wsrep_thd_binlog_stmt_rollback()