### PR TITLE
MDEV-31335 : Create sequence can cause inconsistency

### DIFF
--- a/mysql-test/suite/galera/r/galera_sequences.result
+++ b/mysql-test/suite/galera/r/galera_sequences.result
@@ -79,30 +79,31 @@ SET SESSION autocommit=1;
 DROP SEQUENCE seq1;
 DROP SEQUENCE seq2;
 DROP TABLE t2;
+connection node_2;
 SET SESSION AUTOCOMMIT=0;
 SET SESSION wsrep_OSU_method='RSU';
 CREATE TABLE t1(c1 VARCHAR(10));
-INSERT INTO t1 (c1) VALUES('');
 create temporary sequence sq1 NOCACHE engine=innodb;
 create sequence sq2 NOCACHE engine=innodb;
 COMMIT;
+SET SESSION wsrep_OSU_method='TOI';
 SHOW CREATE SEQUENCE sq1;
 Table	Create Table
 sq1	CREATE SEQUENCE `sq1` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB
 SHOW CREATE SEQUENCE sq2;
 Table	Create Table
 sq2	CREATE SEQUENCE `sq2` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB
-connection node_2;
+connection node_1;
 SHOW CREATE SEQUENCE sq1;
 ERROR 42S02: Table 'test.sq1' doesn't exist
 SHOW CREATE SEQUENCE sq2;
 ERROR 42S02: Table 'test.sq2' doesn't exist
-connection node_1;
+connection node_2;
 SET SESSION AUTOCOMMIT=1;
 DROP TABLE t1;
 DROP SEQUENCE sq1;
 DROP SEQUENCE sq2;
-SET SESSION wsrep_OSU_method='TOI';
+connection node_1;
 CREATE TABLE t (f INT) engine=innodb;
 LOCK TABLE t WRITE;
 CREATE OR REPLACE SEQUENCE t MAXVALUE=13 INCREMENT BY 1 NOCACHE engine=innodb;

--- a/mysql-test/suite/galera/r/galera_temporary_sequences.result
+++ b/mysql-test/suite/galera/r/galera_temporary_sequences.result
@@ -1,0 +1,46 @@
+connection node_2;
+connection node_1;
+connection node_2;
+set autocommit=0;
+SET SESSION wsrep_OSU_method='RSU';
+create table t (i int primary key, j int);
+create temporary sequence seq2 NOCACHE engine=innodb;
+commit;
+SET SESSION wsrep_OSU_method='RSU';
+create sequence seq1 NOCACHE engine=innodb;
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t;
+DROP SEQUENCE seq2;
+DROP SEQUENCE seq1;
+connection node_1;
+create table t (i int primary key, j int);
+set autocommit=0;
+insert into t values (3,0);
+create temporary sequence seq1 NOCACHE engine=innodb;
+commit;
+insert into t values (4,0);
+create sequence seq2 NOCACHE engine=innodb;
+commit;
+connection node_2;
+select * from t;
+i	j
+3	0
+4	0
+show create table seq1;
+ERROR 42S02: Table 'test.seq1' doesn't exist
+show create table seq2;
+Table	Create Table
+seq2	CREATE TABLE `seq2` (
+  `next_not_cached_value` bigint(21) NOT NULL,
+  `minimum_value` bigint(21) NOT NULL,
+  `maximum_value` bigint(21) NOT NULL,
+  `start_value` bigint(21) NOT NULL COMMENT 'start value when sequences is created or value if RESTART is used',
+  `increment` bigint(21) NOT NULL COMMENT 'increment value',
+  `cache_size` bigint(21) unsigned NOT NULL,
+  `cycle_option` tinyint(1) unsigned NOT NULL COMMENT '0 if no cycles are allowed, 1 if the sequence should begin a new cycle when maximum_value is passed',
+  `cycle_count` bigint(21) NOT NULL COMMENT 'How many cycles have been done'
+) ENGINE=InnoDB SEQUENCE=1
+connection node_1;
+DROP TABLE t;
+DROP SEQUENCE seq1;
+DROP SEQUENCE seq2;

--- a/mysql-test/suite/galera/t/galera_sequences.test
+++ b/mysql-test/suite/galera/t/galera_sequences.test
@@ -72,33 +72,33 @@ DROP TABLE t2;
 #
 # Case2
 #
+--connection node_2
 SET SESSION AUTOCOMMIT=0;
 SET SESSION wsrep_OSU_method='RSU';
 CREATE TABLE t1(c1 VARCHAR(10));
-INSERT INTO t1 (c1) VALUES('');
 create temporary sequence sq1 NOCACHE engine=innodb;
 create sequence sq2 NOCACHE engine=innodb;
 COMMIT;
+SET SESSION wsrep_OSU_method='TOI';
 SHOW CREATE SEQUENCE sq1;
-SHOW CREATE SEQUENCE sq2;
---connection node_2
---error ER_NO_SUCH_TABLE
-SHOW CREATE SEQUENCE sq1;
---error ER_NO_SUCH_TABLE
 SHOW CREATE SEQUENCE sq2;
 --connection node_1
+--error ER_NO_SUCH_TABLE
+SHOW CREATE SEQUENCE sq1;
+--error ER_NO_SUCH_TABLE
+SHOW CREATE SEQUENCE sq2;
+--connection node_2
 SET SESSION AUTOCOMMIT=1;
 DROP TABLE t1;
 DROP SEQUENCE sq1;
 DROP SEQUENCE sq2;
-SET SESSION wsrep_OSU_method='TOI';
 
 #
 # MDEV-30388 Assertion `!wsrep_has_changes(thd) || (thd->lex->sql_command == SQLCOM_CREATE_TABLE
 # && !thd->is_current_stmt_binlog_format_row()) ||
 # thd->wsrep_cs().transaction().state() == wsrep::transaction::s_aborted' failed
 #
-
+--connection node_1
 CREATE TABLE t (f INT) engine=innodb;
 LOCK TABLE t WRITE;
 CREATE OR REPLACE SEQUENCE t MAXVALUE=13 INCREMENT BY 1 NOCACHE engine=innodb;

--- a/mysql-test/suite/galera/t/galera_temporary_sequences.test
+++ b/mysql-test/suite/galera/t/galera_temporary_sequences.test
@@ -1,0 +1,37 @@
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+--connection node_2
+set autocommit=0;
+SET SESSION wsrep_OSU_method='RSU';
+create table t (i int primary key, j int);
+create temporary sequence seq2 NOCACHE engine=innodb;
+commit;
+SET SESSION wsrep_OSU_method='RSU';
+create sequence seq1 NOCACHE engine=innodb;
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t;
+DROP SEQUENCE seq2;
+DROP SEQUENCE seq1;
+
+--connection node_1
+create table t (i int primary key, j int);
+set autocommit=0;
+insert into t values (3,0);
+create temporary sequence seq1 NOCACHE engine=innodb;
+commit;
+insert into t values (4,0);
+create sequence seq2 NOCACHE engine=innodb;
+commit;
+
+--connection node_2
+select * from t;
+--error ER_NO_SUCH_TABLE
+show create table seq1;
+show create table seq2;
+
+
+--connection node_1
+DROP TABLE t;
+DROP SEQUENCE seq1;
+DROP SEQUENCE seq2;


### PR DESCRIPTION
Do not start TOI for CREATE TEMPORARY SEQUENCE because object is local only and not replicated. Similarly, avoid starting RSU for TEMPORARY SEQUENCEs. Finally, we need to run commit hooks for TEMPORARY SEQUENCEs because CREATE TEMPORARY SEQUENCE does implicit
commit for previous changes that need to be replicated and committed.