### PR TITLE
MDEV-28198 : Assertion `wsrep_thd_is_applying(thd) && !wsrep_thd_is_l…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-28198.result
+++ b/mysql-test/suite/galera/r/mdev-28198.result
@@ -1,0 +1,32 @@
+connection node_2;
+connection node_1;
+SET GLOBAL log_output='TABLE';
+SET SESSION sql_mode='no_auto_value_on_zero';
+SET SESSION enforce_storage_engine=InnoDB;
+ALTER TABLE mysql.general_log ENGINE=MyISAM;
+ERROR HY000: You cannot 'ALTER' a log table if logging is enabled
+SET GLOBAL general_log=1;
+SELECT 1;
+1
+1
+SET GLOBAL log_output=DEFAULT;
+SET SESSION sql_mode=DEFAULT;
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT.*");
+SET GLOBAL wsrep_forced_binlog_format=STATEMENT;
+CREATE TABLE t (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,3 AS c;
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. CREATE... REPLACE SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are replaced. This order cannot be predicted and may differ on master and the slave
+SELECT * from t;
+a	b
+1	3
+DROP TABLE t;
+SET GLOBAL wsrep_forced_binlog_format=DEFAULT;
+call mtr.add_suppression("BINLOG_BASE64_EVENT: Could not read field.*");
+call mtr.add_suppression("BINLOG_BASE64_EVENT: Could not execute Write_rows_v1 event on table.*");
+CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT, KEY(b)) engine=innodb;
+BINLOG 'AMqaOw8BAAAAdAAAAHgAAAAAAAQANS42LjM0LTc5LjEtZGVidWctbG9nAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAEzgNAAgAEgAEBAQEEgAAXAAEGggAAAAICAgCAAAACgoKGRkAAYVx w2w=';
+BINLOG 'wlZOTxMBAAAAKgAAADwCAAAAACkAAAAAAAEABHRlc3QAAnQxAAIDAwAC wlZOTxcBAAAAJgAAAGICAAAAACkAAAAAAAEAAv/8AgAAAAgAAAA=';
+ERROR HY000: Got error 171 "The event was corrupt, leading to illegal data being read" from storage engine InnoDB
+SELECT * FROM t1;
+a	b
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/mdev-28198.test
+++ b/mysql-test/suite/galera/t/mdev-28198.test
@@ -1,0 +1,29 @@
+--source include/galera_cluster.inc
+
+
+SET GLOBAL log_output='TABLE';
+SET SESSION sql_mode='no_auto_value_on_zero';
+SET SESSION enforce_storage_engine=InnoDB;
+--error ER_BAD_LOG_STATEMENT
+ALTER TABLE mysql.general_log ENGINE=MyISAM;
+SET GLOBAL general_log=1;
+SELECT 1;
+SET GLOBAL log_output=DEFAULT;
+SET SESSION sql_mode=DEFAULT;
+
+
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT.*");
+SET GLOBAL wsrep_forced_binlog_format=STATEMENT;
+CREATE TABLE t (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,3 AS c;
+SELECT * from t;
+DROP TABLE t;
+SET GLOBAL wsrep_forced_binlog_format=DEFAULT;
+
+call mtr.add_suppression("BINLOG_BASE64_EVENT: Could not read field.*");
+call mtr.add_suppression("BINLOG_BASE64_EVENT: Could not execute Write_rows_v1 event on table.*");
+CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT, KEY(b)) engine=innodb;
+BINLOG 'AMqaOw8BAAAAdAAAAHgAAAAAAAQANS42LjM0LTc5LjEtZGVidWctbG9nAAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAAAAAAEzgNAAgAEgAEBAQEEgAAXAAEGggAAAAICAgCAAAACgoKGRkAAYVx w2w=';
+--error ER_GET_ERRNO
+BINLOG 'wlZOTxMBAAAAKgAAADwCAAAAACkAAAAAAAEABHRlc3QAAnQxAAIDAwAC wlZOTxcBAAAAJgAAAGICAAAAACkAAAAAAAEAAv/8AgAAAAgAAAA=';
+SELECT * FROM t1;
+DROP TABLE t1;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008-2022 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2023 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -2799,8 +2799,9 @@ int wsrep_ignored_error_code(Log_event* ev, int error)
   const THD* thd= ev->thd;
 
   DBUG_ASSERT(error);
-  DBUG_ASSERT(wsrep_thd_is_applying(thd) &&
-              !wsrep_thd_is_local_toi(thd));
+  /* Note that binlog events can be executed on master also with
+     BINLOG '....'; */
+  DBUG_ASSERT(!wsrep_thd_is_local_toi(thd));
 
   if ((wsrep_ignore_apply_errors & WSREP_IGNORE_ERRORS_ON_RECONCILING_DML))
   {


### PR DESCRIPTION
…ocal_toi(thd)' failed in int wsrep_ignored_error_code(Log_event*, int)

There is actually two problems. Firstly, at wsrep_ignored_error_code we need to allow binlog events because you can use BINLOG = 'xxx' also to master. Secondly, at ha_innobase::update_row we should not add keys if wsrep transaction is already aborted state.