### PR TITLE
MDEV-31660 : Assertion `client_state.transaction().active() in wsrep_…

### DIFF
--- a/mysql-test/suite/galera/r/create.result
+++ b/mysql-test/suite/galera/r/create.result
@@ -18,6 +18,8 @@ USE test;
 CREATE TABLE t1(i INT) ENGINE=INNODB;
 INSERT INTO t1 VALUES(1);
 CREATE TEMPORARY TABLE `t1_temp` AS SELECT * FROM `t1` WHERE i = 1;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
 SELECT * FROM t1;
 i
 1

--- a/mysql-test/suite/galera/r/galera_forced_binlog_format_ctas.result
+++ b/mysql-test/suite/galera/r/galera_forced_binlog_format_ctas.result
@@ -1,0 +1,273 @@
+connection node_2;
+connection node_1;
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+SET GLOBAL wsrep_forced_binlog_format=ROW;
+connection node_1;
+CREATE TABLE t1(a int not null primary key auto_increment, b int) ENGINE=InnoDB;
+CREATE TABLE t2(a int not null primary key, b int) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2);
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+CREATE TABLE t3 AS SELECT * FROM t1;
+CREATE TABLE t4 AS SELECT * FROM t2;
+CREATE TABLE t5 (a INT UNIQUE) AS SELECT 1 AS a;
+CREATE TABLE t6 (a INT UNIQUE) REPLACE SELECT 1 AS a;
+CREATE TABLE t7 (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,
+3 AS c;
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_2;
+# Veryfy CTAS replication
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_1;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7;
+SET GLOBAL wsrep_forced_binlog_format=STATEMENT;
+connection node_1;
+CREATE TABLE t1(a int not null primary key auto_increment, b int) ENGINE=InnoDB;
+CREATE TABLE t2(a int not null primary key, b int) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+INSERT INTO t1(b) SELECT b+1 from t1;
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+INSERT INTO t1(b) SELECT b+1 from t1;
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+INSERT INTO t1(b) SELECT b+1 from t1;
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+INSERT INTO t1(b) SELECT b+1 from t1;
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+CREATE TABLE t3 AS SELECT * FROM t1;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
+CREATE TABLE t4 AS SELECT * FROM t2;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
+CREATE TABLE t5 (a INT UNIQUE) AS SELECT 1 AS a;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
+CREATE TABLE t6 (a INT UNIQUE) REPLACE SELECT 1 AS a;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
+CREATE TABLE t7 (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,
+3 AS c;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = STMT in CREATE TABLE AS SELECT
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_2;
+# Veryfy CTAS replication
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_1;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7;
+SET GLOBAL wsrep_forced_binlog_format=MIXED;
+connection node_1;
+CREATE TABLE t1(a int not null primary key auto_increment, b int) ENGINE=InnoDB;
+CREATE TABLE t2(a int not null primary key, b int) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2);
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+CREATE TABLE t3 AS SELECT * FROM t1;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = MIXED in CREATE TABLE AS SELECT
+CREATE TABLE t4 AS SELECT * FROM t2;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = MIXED in CREATE TABLE AS SELECT
+CREATE TABLE t5 (a INT UNIQUE) AS SELECT 1 AS a;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = MIXED in CREATE TABLE AS SELECT
+CREATE TABLE t6 (a INT UNIQUE) REPLACE SELECT 1 AS a;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = MIXED in CREATE TABLE AS SELECT
+CREATE TABLE t7 (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,
+3 AS c;
+Warnings:
+Warning	1105	Galera does not support wsrep_forced_binlog_format = MIXED in CREATE TABLE AS SELECT
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_2;
+# Veryfy CTAS replication
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_1;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7;
+SET GLOBAL wsrep_forced_binlog_format=NONE;
+connection node_1;
+CREATE TABLE t1(a int not null primary key auto_increment, b int) ENGINE=InnoDB;
+CREATE TABLE t2(a int not null primary key, b int) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2);
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+CREATE TABLE t3 AS SELECT * FROM t1;
+CREATE TABLE t4 AS SELECT * FROM t2;
+CREATE TABLE t5 (a INT UNIQUE) AS SELECT 1 AS a;
+CREATE TABLE t6 (a INT UNIQUE) REPLACE SELECT 1 AS a;
+CREATE TABLE t7 (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,
+3 AS c;
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_2;
+# Veryfy CTAS replication
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+EXPECT_32
+32
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+EXPECT_32
+32
+SELECT * FROM t4;
+a	b
+SELECT * FROM t5;
+a
+1
+SELECT * FROM t6;
+a
+1
+SELECT * FROM t7;
+a	b
+1	3
+connection node_1;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7;

--- a/mysql-test/suite/galera/t/galera_forced_binlog_ctas_test.inc
+++ b/mysql-test/suite/galera/t/galera_forced_binlog_ctas_test.inc
@@ -1,0 +1,50 @@
+--connection node_1
+CREATE TABLE t1(a int not null primary key auto_increment, b int) ENGINE=InnoDB;
+CREATE TABLE t2(a int not null primary key, b int) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2);
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+INSERT INTO t1(b) SELECT b+1 from t1;
+CREATE TABLE t3 AS SELECT * FROM t1;
+CREATE TABLE t4 AS SELECT * FROM t2;
+CREATE TABLE t5 (a INT UNIQUE) AS SELECT 1 AS a;
+CREATE TABLE t6 (a INT UNIQUE) REPLACE SELECT 1 AS a;
+CREATE TABLE t7 (a INT UNIQUE) REPLACE SELECT 1 AS a,2 AS b UNION SELECT 1 AS a,
+3 AS c;
+
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+SELECT * FROM t4;
+SELECT * FROM t5;
+SELECT * FROM t6;
+SELECT * FROM t7;
+
+--connection node_2
+--echo # Veryfy CTAS replication
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't4'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't5'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't6'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't7'
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS EXPECT_32 FROM t1;
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+SELECT COUNT(*) AS EXPECT_32 FROM t3;
+SELECT * FROM t4;
+SELECT * FROM t5;
+SELECT * FROM t6;
+SELECT * FROM t7;
+
+--connection node_1
+DROP TABLE t1,t2,t3,t4,t5,t6,t7;

--- a/mysql-test/suite/galera/t/galera_forced_binlog_format_ctas.test
+++ b/mysql-test/suite/galera/t/galera_forced_binlog_format_ctas.test
@@ -1,0 +1,19 @@
+--source include/galera_cluster.inc
+
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+
+SET GLOBAL wsrep_forced_binlog_format=ROW;
+
+--source suite/galera/t/galera_forced_binlog_ctas_test.inc
+
+SET GLOBAL wsrep_forced_binlog_format=STATEMENT;
+
+--source suite/galera/t/galera_forced_binlog_ctas_test.inc
+
+SET GLOBAL wsrep_forced_binlog_format=MIXED;
+
+--source suite/galera/t/galera_forced_binlog_ctas_test.inc
+
+SET GLOBAL wsrep_forced_binlog_format=NONE;
+
+--source suite/galera/t/galera_forced_binlog_ctas_test.inc

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -3433,7 +3433,8 @@ thr_lock_type read_lock_type_for_table(THD *thd,
     at THD::variables::sql_log_bin member.
   */
   bool log_on= mysql_bin_log.is_open() && thd->variables.sql_log_bin;
-  if ((log_on == FALSE) || (thd->wsrep_binlog_format() == BINLOG_FORMAT_ROW) ||
+  if ((log_on == FALSE) ||
+      (thd->wsrep_binlog_format(thd->variables.binlog_format) == BINLOG_FORMAT_ROW) ||
       (table_list->table->s->table_category == TABLE_CATEGORY_LOG) ||
       (table_list->table->s->table_category == TABLE_CATEGORY_PERFORMANCE) ||
       !(is_update_query(prelocking_ctx->sql_command) ||

--- a/sql/sql_error.cc
+++ b/sql/sql_error.cc
@@ -537,6 +537,18 @@ bool Warning_info::has_sql_condition(const char *message_str, size_t message_len
   return false;
 }
 
+bool Warning_info::has_sql_condition(uint sql_errno) const
+{
+  Diagnostics_area::Sql_condition_iterator it(m_warn_list);
+  const Sql_condition *err;
+
+  while ((err = it++))
+  {
+    if (err->get_sql_errno() == sql_errno)
+      return true;
+  }
+  return false;
+}
 
 void Warning_info::clear(ulonglong new_id)
 {

--- a/sql/sql_error.h
+++ b/sql/sql_error.h
@@ -592,6 +592,16 @@ private:
   bool has_sql_condition(const char *message_str, size_t message_length) const;
 
   /**
+    Checks if Warning_info contains SQL-condition with the given error id
+
+    @param sql_errno SQL-condition error number
+
+    @return true if the Warning_info contains an SQL-condition with the given
+    error id.
+  */
+  bool has_sql_condition(uint sql_errno) const;
+
+  /**
     Reset the warning information. Clear all warnings,
     the number of warnings, reset current row counter
     to point to the first row.
@@ -1125,6 +1135,9 @@ public:
 
   bool has_sql_condition(const char *message_str, size_t message_length) const
   { return get_warning_info()->has_sql_condition(message_str, message_length); }
+
+  bool has_sql_condition(uint sql_errno) const
+  { return get_warning_info()->has_sql_condition(sql_errno); }
 
   void reset_for_next_command()
   { get_warning_info()->reset_for_next_command(); }

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -474,7 +474,7 @@ void upgrade_lock_type(THD *thd, thr_lock_type *lock_type,
     }
 
     bool log_on= (thd->variables.option_bits & OPTION_BIN_LOG);
-    if (WSREP_BINLOG_FORMAT(global_system_variables.binlog_format) == BINLOG_FORMAT_STMT &&
+    if (thd->wsrep_binlog_format(global_system_variables.binlog_format) == BINLOG_FORMAT_STMT &&
         log_on && mysql_bin_log.is_open())
     {
       /*

--- a/sql/wsrep_on.h
+++ b/sql/wsrep_on.h
@@ -46,10 +46,6 @@ extern ulong wsrep_forced_binlog_format;
 #define WSREP_EMULATE_BINLOG(thd) \
   (WSREP(thd) && wsrep_emulate_bin_log)
 
-#define WSREP_BINLOG_FORMAT(my_format) \
-   ((wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC) ? \
-   wsrep_forced_binlog_format : my_format)
-
 #else
 
 #define WSREP_ON false
@@ -57,7 +53,6 @@ extern ulong wsrep_forced_binlog_format;
 #define WSREP_NNULL(T) (0)
 #define WSREP_EMULATE_BINLOG(thd) (0)
 #define WSREP_EMULATE_BINLOG_NNULL(thd) (0)
-#define WSREP_BINLOG_FORMAT(my_format) ((ulong)my_format)
 
 #endif
 #endif


### PR DESCRIPTION
…append_key

At the moment we cannot support
wsrep_forced_binlog_format=[MIXED|STATEMENT]
during CREATE TABLE AS SELECT.
Statement will use ROW instead and give
a warning.