### PR TITLE
MDEV-29861 : Galera "notify" test cases hang

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -13,10 +13,6 @@
 galera_as_slave_ctas : MDEV-28378 timeout
 galera_pc_recovery : MDEV-25199 cluster fails to start up
 galera_sst_encrypted : MDEV-29876 Galera test failure on galera_sst_encrypted
-galera.MW-284 : MDEV-29861 Galera test case hangs
-galera.galera_binlog_checksum : MDEV-29861 Galera test case hangs
-galera_var_notify_ssl_ipv6 : MDEV-29861 Galera test case hangs
-galera_var_notify_cmd: MDEV-29861 Galera test case hangs
 galera_var_node_address : MDEV-20485 Galera test failure
 MDEV-26575 : MDEV-29878 Galera test failure on MDEV-26575
 galera_bf_abort_group_commit : MDEV-30855 PR to remove the test exists

--- a/sql/wsrep_notify.cc
+++ b/sql/wsrep_notify.cc
@@ -21,6 +21,13 @@
 void wsrep_notify_status(enum wsrep::server_state::state status,
                          const wsrep::view* view)
 {
+  if (!view)
+  {
+    WSREP_DEBUG("wsrep_notify_status server not yet ready : wsrep_ready=%d status %d",
+		wsrep_ready, (int)status);
+    return;
+  }
+
   if (!wsrep_notify_cmd || 0 == strlen(wsrep_notify_cmd))
   {
     WSREP_INFO("wsrep_notify_cmd is not defined, skipping notification.");

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -189,7 +189,11 @@ public:
 
   void set(enum wsrep::server_state::state status)
   {
-    wsrep_notify_status(status);
+    if (status == wsrep::server_state::s_donor ||
+	status == wsrep::server_state::s_synced)
+      wsrep_notify_status(status, &view_);
+    else
+      wsrep_notify_status(status);
 
     lock();
     status_= status;


### PR DESCRIPTION
Problem was that if wsrep_notify_cmd was set it was called with a new status "joined" it tries to connect to the server to update some table, but the server isn't initialized yet, it's not listening for connections. So the server waits for the script to finish, script waits for mariadb client to connect, and the client cannot connect, because the server isn't listening.

Fix is to call script only when Galera has already formed a view or when it is synched or donor.

This fix also enables following test cases:
* galera.MW-284
* galera.galera_binlog_checksum
* galera_var_notify_ssl_ipv6