### PR TITLE
TODO-4256 : Set Galera library as submodule for MariaDB server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,7 @@
 [submodule "extra/wolfssl/wolfssl"]
 	path = extra/wolfssl/wolfssl
 	url = https://github.com/wolfSSL/wolfssl.git
+[submodule "plugin/galera_replication/galera"]
+	path = plugin/galera_replication/galera
+	url = git@github.com:MariaDB/galera.git
+	branch = mariadb-4.x

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -2498,6 +2498,7 @@ sub setup_vardir() {
 
         for (<$bindir/storage/*$multiconfig/*.so>,
              <$bindir/plugin/*$multiconfig/*.so>,
+	     <$bindir/plugin/galera_replication/galera/*.so>,
              <$bindir/libmariadb/plugins/*/*.so>,
              <$bindir/libmariadb/$multiconfig/*.so>,
              <$bindir/sql$multiconfig/*.so>)

--- a/mysql-test/suite/wsrep/common.pm
+++ b/mysql-test/suite/wsrep/common.pm
@@ -89,7 +89,9 @@ sub check_wsrep_support() {
     # WSREP_PROVIDER env not defined. Lets try to locate the wsrep provider
     # library.
     $file_wsrep_provider=
-      ::mtr_file_exists("/usr/lib64/galera-4/libgalera_smm.so",
+	::mtr_file_exists("$basedir/lib/plugin/libgalera_smm.so",
+                      "$::bindir/plugin/galera_replication/galera/libgalera_smm.so",
+                      "/usr/lib64/galera-4/libgalera_smm.so",
                       "/usr/lib64/galera/libgalera_smm.so",
                       "/usr/lib/galera-4/libgalera_smm.so",
                       "/usr/lib/galera/libgalera_smm.so");

--- a/plugin/galera_replication/CMakeLists.txt
+++ b/plugin/galera_replication/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright (C) 2023 Codership Oy <info@galeracluster.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is also distributed with certain software (including
+# but not limited to OpenSSL) that is licensed under separate terms,
+# as designated in a particular file or component or in included license
+# documentation.  The authors of MySQL hereby grant you an additional
+# permission to link the program and your derivative works with the
+# separately licensed software that they have included with MySQL.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+OPTION(WITH_WSREP "Build Galera library" OFF)
+
+MESSAGE(STATUS "Building with Galera ${WITH_WSREP}")
+
+IF(NOT WITH_WSREP)
+  RETURN()
+ENDIF()
+
+IF (WITH_WSREP)
+
+  IF(NOT EXISTS "${CMAKE_SOURCE_DIR}/plugin/galera_replication/galera/GALERA_VERSION")
+    MESSAGE(FATAL_ERROR "No MariaDB galera library code! Run
+    ${GIT_EXECUTABLE} submodule update --init --recursive
+Then restart the build.
+")
+  ENDIF()
+
+  ADD_SUBDIRECTORY(galera)
+
+  INSTALL(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/galera/libgalera_smm.so"
+    DESTINATION ${INSTALL_PLUGINDIR}
+    COMPONENT Server)
+  INSTALL(PROGRAMS
+    "${CMAKE_CURRENT_BINARY_DIR}/galera/garb/garbd"
+    DESTINATION ${INSTALL_BINDIR}
+    COMPONENT Server)
+ENDIF()


### PR DESCRIPTION
Rationale: Before this change MariaDB server and Galera library were released on different times. Normally this ment that new Galera library version was pushed to repository and then you could fix possible test failures on MariaDB server regression testing. Mostly test failures was caused by new configuration variables or new visible status variables. Sometimes there was also other regressions possible and those might not be always visible on local testing. In Jenkings etc it is possible to test with some version of the galera library. This change makes it possible to have both galera library release and necessary
MariaDB fixes on same commit and both are then tested on staging branch before they are pushed on main
branch.