### PR TITLE
MDEV-31273: Precompute binlog checksums

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -30,6 +30,7 @@
 #define NUMBER_OF_FIELDS_TO_IDENTIFY_WORKER 2
 #include "slave.h"
 #include "rpl_mi.h"
+#include "rpl_constants.h"
 
 namespace
 {
@@ -70,7 +71,7 @@ static rpl_group_info* wsrep_relay_group_init(THD* thd, const char* log_fname)
   if (!rli->relay_log.description_event_for_exec)
   {
     rli->relay_log.description_event_for_exec=
-      new Format_description_log_event(4);
+      new Format_description_log_event(4, 0, BINLOG_CHECKSUM_ALG_OFF);
   }
 
   static LEX_CSTRING connection_name= { STRING_WITH_LEN("wsrep") };


### PR DESCRIPTION
After b8f9f796 Format_description_log_event constructor requires binlog checksum algorithm or BINLOG_CHECKSUM_ALG_OFF for Galera also.