### PR TITLE
MDEV-22063 : Assertion `0' failed in wsrep::transaction::before_rollback

### DIFF
--- a/mysql-test/suite/galera/r/galera_myisam_autocommit.result
+++ b/mysql-test/suite/galera/r/galera_myisam_autocommit.result
@@ -1,5 +1,6 @@
 connection node_2;
 connection node_1;
+SET GLOBAL wsrep_replicate_myisam=ON;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=MyISAM;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (2), (3);
@@ -14,14 +15,37 @@ UPDATE t1 SET f1 = 9;
 UPDATE t2 SET f1 = 9 WHERE f1 = 1;
 DELETE FROM t1 WHERE f1 = 9;
 DELETE FROM t2 WHERE f1 = 9;
-TRUNCATE TABLE t1;
-TRUNCATE TABLE t1;
+SELECT * FROM t1 ORDER BY f1;
+f1
+SELECT * FROM t2 ORDER BY f1;
+f1
+2
+3
+4
+5
+6
 connection node_2;
-SELECT COUNT(*) = 0 FROM t1;
-COUNT(*) = 0
-1
-SELECT COUNT(*) = 0 FROM t2;
-COUNT(*) = 0
-1
+SELECT * FROM t1 ORDER BY f1;
+f1
+SELECT * FROM t2 ORDER BY f1;
+f1
+2
+3
+4
+5
+6
+TRUNCATE TABLE t1;
+TRUNCATE TABLE t2;
+SELECT * FROM t1 ORDER BY f1;
+f1
+SELECT * FROM t2 ORDER BY f1;
+f1
+connection node_2;
+SELECT * FROM t1 ORDER BY f1;
+f1
+SELECT * FROM t2 ORDER BY f1;
+f1
+connection node_1;
+SET GLOBAL wsrep_replicate_myisam=OFF;
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera/r/mdev-22063.result
+++ b/mysql-test/suite/galera/r/mdev-22063.result
@@ -1,0 +1,242 @@
+connection node_2;
+connection node_1;
+# Case 1 CREATE SEQUENCE with no NOCACHE
+CREATE SEQUENCE s ENGINE=InnoDB;
+ERROR 42000: This version of MariaDB doesn't yet support 'CACHE without INCREMENT BY 0 in Galera cluster'
+CREATE SEQUENCE s NOCACHE ENGINE=InnoDB;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+START TRANSACTION;
+REPLACE INTO s VALUES (1,1,9223372036854775806,1,1,1000,0,0);
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+SELECT * FROM t1;
+a
+SELECT * FROM s;
+next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
+1	1	9223372036854775806	1	1	1000	0	0
+connection node_2;
+SELECT * FROM t1;
+a
+SELECT * FROM s;
+next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
+1	1	9223372036854775806	1	1	1000	0	0
+connection node_1;
+DROP TABLE t1;
+DROP SEQUENCE s;
+# Case 2 REPLACE INTO ... SELECT with error
+CREATE TABLE t (id INT KEY,a YEAR,INDEX (id,a)) engine=innodb;
+REPLACE INTO t (id,a)SELECT /*!99997 */ 1;
+ERROR 21S01: Column count doesn't match value count at row 1
+REPLACE INTO t (id,a)SELECT /*!99997 */ 1,2;
+SELECT * FROM t;
+id	a
+1	2002
+CREATE TABLE t2 (id INT KEY,a YEAR,INDEX (id,a)) engine=myisam;
+REPLACE INTO t2 (id,a)SELECT /*!99997 */ 1;
+ERROR 21S01: Column count doesn't match value count at row 1
+REPLACE INTO t2 (id,a)SELECT /*!99997 */ 1,2;
+Warnings:
+Warning	138	Galera cluster does support consistency check only for InnoDB tables.
+SELECT * FROM t2;
+id	a
+1	2002
+CREATE TABLE t3 (id INT KEY,a YEAR,INDEX (id,a)) engine=aria;
+REPLACE INTO t3 (id,a)SELECT /*!99997 */ 1;
+ERROR 21S01: Column count doesn't match value count at row 1
+REPLACE INTO t3 (id,a)SELECT /*!99997 */ 1,2;
+Warnings:
+Warning	138	Galera cluster does support consistency check only for InnoDB tables.
+SELECT * FROM t3;
+id	a
+1	2002
+connection node_2;
+SELECT * FROM t;
+id	a
+1	2002
+SELECT * FROM t2;
+id	a
+1	2002
+SELECT * FROM t3;
+id	a
+1	2002
+connection node_1;
+DROP TABLE t,t2,t3;
+# Bigger REPLACE ... AS SELECT test
+SET GLOBAL wsrep_replicate_myisam=ON;
+CREATE TABLE t1(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t2(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t3(id int not null primary key ,b int) ENGINE=Aria;
+CREATE TABLE t4(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t5(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t6(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t7(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t8(id int not null primary key ,b int) ENGINE=Aria;
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t2(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t3(id) SELECT seq FROM seq_1_to_1000;
+REPLACE INTO t4 SELECT * FROM t1;
+REPLACE INTO t5 SELECT * FROM t2;
+REPLACE INTO t6 SELECT * FROM t3;
+REPLACE INTO t7 SELECT * FROM t2;
+REPLACE INTO t8 SELECT * FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+EXPECT_1000
+1000
+connection node_2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+EXPECT_1000
+1000
+connection node_1;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+# Bigger INSERT INTO ... SELECT test
+CREATE TABLE t1(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t2(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t3(id int not null primary key ,b int) ENGINE=Aria;
+CREATE TABLE t4(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t5(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t6(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t7(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t8(id int not null primary key ,b int) ENGINE=Aria;
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t2(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t3(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t4 SELECT * FROM t1;
+INSERT INTO t5 SELECT * FROM t2;
+INSERT INTO t6 SELECT * FROM t3;
+INSERT INTO t7 SELECT * FROM t2;
+INSERT INTO t8 SELECT * FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+EXPECT_1000
+1000
+connection node_2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+EXPECT_1000
+1000
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+EXPECT_1000
+1000
+connection node_1;
+SET GLOBAL wsrep_replicate_myisam=OFF;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+CREATE TABLE t1(pk int not null primary key) engine=innodb;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+pk
+1
+2
+3
+4
+5
+DROP TABLE t1;
+DROP VIEW view_t1;
+CREATE TABLE t1(pk int not null primary key) engine=myisam;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+pk
+1
+2
+3
+4
+5
+DROP TABLE t1;
+DROP VIEW view_t1;
+CREATE TABLE t1(pk int not null primary key) engine=aria;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+pk
+1
+2
+3
+4
+5
+DROP TABLE t1;
+DROP VIEW view_t1;

--- a/mysql-test/suite/galera/t/galera_myisam_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_myisam_autocommit.test
@@ -2,8 +2,10 @@
 --source include/have_innodb.inc
 
 #
-# This tests simple autocommit replication of MyISAM tables. No updates arrive on the slave.
+# This tests simple autocommit replication of MyISAM tables.
 #
+
+SET GLOBAL wsrep_replicate_myisam=ON;
 
 # Without a PK
 
@@ -11,11 +13,13 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=MyISAM;
 
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (2), (3);
+# This is TOI
 INSERT INTO t1 SELECT 4 FROM DUAL UNION ALL SELECT 5 FROM DUAL;
 
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 INSERT INTO t2 VALUES (1);
 INSERT INTO t2 VALUES (2), (3);
+# This is TOI
 INSERT INTO t2 SELECT 4 FROM DUAL UNION ALL SELECT 5 FROM DUAL;
 
 # Error
@@ -32,14 +36,26 @@ UPDATE t2 SET f1 = 9 WHERE f1 = 1;
 DELETE FROM t1 WHERE f1 = 9;
 DELETE FROM t2 WHERE f1 = 9;
 
+SELECT * FROM t1 ORDER BY f1;
+SELECT * FROM t2 ORDER BY f1;
+
+--connection node_2
+SELECT * FROM t1 ORDER BY f1;
+SELECT * FROM t2 ORDER BY f1;
+
 # TRUNCATE
 
 TRUNCATE TABLE t1;
-TRUNCATE TABLE t1;
+TRUNCATE TABLE t2;
+
+SELECT * FROM t1 ORDER BY f1;
+SELECT * FROM t2 ORDER BY f1;
 
 --connection node_2
-SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM t2;
+SELECT * FROM t1 ORDER BY f1;
+SELECT * FROM t2 ORDER BY f1;
 
+--connection node_1
+SET GLOBAL wsrep_replicate_myisam=OFF;
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera/t/mdev-22063.test
+++ b/mysql-test/suite/galera/t/mdev-22063.test
@@ -1,0 +1,187 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+--source include/have_sequence.inc
+--source include/have_aria.inc
+
+--echo # Case 1 CREATE SEQUENCE with no NOCACHE
+--error ER_NOT_SUPPORTED_YET
+CREATE SEQUENCE s ENGINE=InnoDB;
+CREATE SEQUENCE s NOCACHE ENGINE=InnoDB;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+START TRANSACTION;
+REPLACE INTO s VALUES (1,1,9223372036854775806,1,1,1000,0,0);
+OPTIMIZE TABLE t1;
+SELECT * FROM t1;
+SELECT * FROM s;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 's'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.s;
+--source include/wait_condition.inc
+
+SELECT * FROM t1;
+SELECT * FROM s;
+
+--connection node_1
+DROP TABLE t1;
+DROP SEQUENCE s;
+
+--echo # Case 2 REPLACE INTO ... SELECT with error
+CREATE TABLE t (id INT KEY,a YEAR,INDEX (id,a)) engine=innodb;
+--error ER_WRONG_VALUE_COUNT_ON_ROW
+REPLACE INTO t (id,a)SELECT /*!99997 */ 1;
+REPLACE INTO t (id,a)SELECT /*!99997 */ 1,2;
+SELECT * FROM t;
+
+CREATE TABLE t2 (id INT KEY,a YEAR,INDEX (id,a)) engine=myisam;
+--error ER_WRONG_VALUE_COUNT_ON_ROW
+REPLACE INTO t2 (id,a)SELECT /*!99997 */ 1;
+REPLACE INTO t2 (id,a)SELECT /*!99997 */ 1,2;
+SELECT * FROM t2;
+
+CREATE TABLE t3 (id INT KEY,a YEAR,INDEX (id,a)) engine=aria;
+--error ER_WRONG_VALUE_COUNT_ON_ROW
+REPLACE INTO t3 (id,a)SELECT /*!99997 */ 1;
+REPLACE INTO t3 (id,a)SELECT /*!99997 */ 1,2;
+SELECT * FROM t3;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t3;
+--source include/wait_condition.inc
+
+SELECT * FROM t;
+SELECT * FROM t2;
+SELECT * FROM t3;
+
+--connection node_1
+DROP TABLE t,t2,t3;
+
+--echo # Bigger REPLACE ... AS SELECT test
+
+SET GLOBAL wsrep_replicate_myisam=ON;
+
+CREATE TABLE t1(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t2(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t3(id int not null primary key ,b int) ENGINE=Aria;
+CREATE TABLE t4(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t5(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t6(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t7(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t8(id int not null primary key ,b int) ENGINE=Aria;
+
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t2(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t3(id) SELECT seq FROM seq_1_to_1000;
+
+REPLACE INTO t4 SELECT * FROM t1;
+REPLACE INTO t5 SELECT * FROM t2;
+REPLACE INTO t6 SELECT * FROM t3;
+REPLACE INTO t7 SELECT * FROM t2;
+REPLACE INTO t8 SELECT * FROM t3;
+
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 8 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't_'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1000 FROM test.t6;
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+
+--connection node_1
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+
+--echo # Bigger INSERT INTO ... SELECT test
+
+CREATE TABLE t1(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t2(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t3(id int not null primary key ,b int) ENGINE=Aria;
+CREATE TABLE t4(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t5(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t6(id int not null primary key ,b int) ENGINE=InnoDB;
+CREATE TABLE t7(id int not null primary key ,b int) ENGINE=MyISAM;
+CREATE TABLE t8(id int not null primary key ,b int) ENGINE=Aria;
+
+INSERT INTO t1(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t2(id) SELECT seq FROM seq_1_to_1000;
+INSERT INTO t3(id) SELECT seq FROM seq_1_to_1000;
+
+INSERT INTO t4 SELECT * FROM t1;
+INSERT INTO t5 SELECT * FROM t2;
+INSERT INTO t6 SELECT * FROM t3;
+INSERT INTO t7 SELECT * FROM t2;
+INSERT INTO t8 SELECT * FROM t3;
+
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 8 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't_'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1000 FROM test.t6;
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS EXPECT_1000 FROM t1;
+SELECT COUNT(*) AS EXPECT_1000 FROM t2;
+SELECT COUNT(*) AS EXPECT_1000 FROM t3;
+SELECT COUNT(*) AS EXPECT_1000 FROM t4;
+SELECT COUNT(*) AS EXPECT_1000 FROM t5;
+SELECT COUNT(*) AS EXPECT_1000 FROM t6;
+SELECT COUNT(*) AS EXPECT_1000 FROM t7;
+SELECT COUNT(*) AS EXPECT_1000 FROM t8;
+
+--connection node_1
+SET GLOBAL wsrep_replicate_myisam=OFF;
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+
+#
+# View
+#
+CREATE TABLE t1(pk int not null primary key) engine=innodb;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+DROP TABLE t1;
+DROP VIEW view_t1;
+CREATE TABLE t1(pk int not null primary key) engine=myisam;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+DROP TABLE t1;
+DROP VIEW view_t1;
+CREATE TABLE t1(pk int not null primary key) engine=aria;
+INSERT INTO t1 values (1),(2),(3),(4);
+CREATE VIEW view_t1 AS SELECT * FROM t1;
+INSERT INTO view_t1 VALUES (5);
+SELECT * FROM t1;
+DROP TABLE t1;
+DROP VIEW view_t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4658,10 +4658,15 @@ mysql_execute_command(THD *thd)
 
     if ((res= insert_precheck(thd, all_tables)))
       break;
+
 #ifdef WITH_WSREP
-    if (WSREP(thd) && thd->wsrep_consistency_check == CONSISTENCY_CHECK_DECLARED)
+    bool wsrep_toi= false;
+    const bool wsrep= WSREP(thd);
+
+    if (wsrep && thd->wsrep_consistency_check == CONSISTENCY_CHECK_DECLARED)
     {
       thd->wsrep_consistency_check = CONSISTENCY_CHECK_RUNNING;
+      wsrep_toi= true;
       WSREP_TO_ISOLATION_BEGIN(first_table->db.str, first_table->table_name.str, NULL);
     }
 #endif /* WITH_WSREP */
@@ -4696,6 +4701,27 @@ mysql_execute_command(THD *thd)
     if (!(res=open_and_lock_tables(thd, all_tables, TRUE, 0)))
     {
       MYSQL_INSERT_SELECT_START(thd->query());
+
+#ifdef WITH_WSREP
+      if (wsrep && !first_table->view)
+      {
+        bool is_innodb= (first_table->table->file->ht->db_type == DB_TYPE_INNODB);
+
+        // For consistency check inserted table needs to be InnoDB
+        if (!is_innodb && thd->wsrep_consistency_check != NO_CONSISTENCY_CHECK)
+        {
+          push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                              HA_ERR_UNSUPPORTED,
+                              "Galera cluster does support consistency check only"
+                              " for InnoDB tables.");
+          thd->wsrep_consistency_check= NO_CONSISTENCY_CHECK;
+        }
+
+        // For !InnoDB we start TOI if it is not yet started and hope for the best
+        if (!is_innodb && !wsrep_toi)
+          WSREP_TO_ISOLATION_BEGIN(first_table->db.str, first_table->table_name.str, NULL);
+      }
+#endif /* WITH_WSREP */
       /*
         Only the INSERT table should be merged. Other will be handled by
         select.


### PR DESCRIPTION
Problem was that we were executing TOI and tried to rollback it and it is not allowed.

This fix we will use streaming replication for REPLACE INTO...SELECT and INSERT INTO...SELECT instead if table engine where REPLACE or INSERT is done is InnoDB. If table engine is not InnoDB we will stil use TOI and hope for the best.