### PR TITLE
MDEV-27806 GTIDs diverge in Galera cluster after CTAS

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-27806.result
+++ b/mysql-test/suite/galera/r/MDEV-27806.result
@@ -1,0 +1,51 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+CREATE TABLE ts1 AS SELECT * FROM t1;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000002	#	Gtid	#	#	BEGIN GTID #-#-#
+mysqld-bin.000002	#	Query	#	#	use `test`; CREATE TABLE `ts1` (
+  `f1` int(11) NOT NULL
+)
+mysqld-bin.000002	#	Annotate_rows	#	#	CREATE TABLE ts1 AS SELECT * FROM t1
+mysqld-bin.000002	#	Table_map	#	#	table_id: # (test.ts1)
+mysqld-bin.000002	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+mysqld-bin.000002	#	Xid	#	#	COMMIT /* XID */
+connection node_2;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000003	#	Gtid	#	#	BEGIN GTID #-#-#
+mysqld-bin.000003	#	Query	#	#	use `test`; CREATE TABLE `ts1` (
+  `f1` int(11) NOT NULL
+)
+mysqld-bin.000003	#	Annotate_rows	#	#	CREATE TABLE ts1 AS SELECT * FROM t1
+mysqld-bin.000003	#	Table_map	#	#	table_id: # (test.ts1)
+mysqld-bin.000003	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+mysqld-bin.000003	#	Xid	#	#	COMMIT /* XID */
+BINLOG_POSITIONS_MATCH
+1
+DROP TABLE t1,ts1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE ts1 AS SELECT * FROM t1;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000002	#	Gtid	#	#	BEGIN GTID #-#-#
+mysqld-bin.000002	#	Query	#	#	use `test`; CREATE TABLE `ts1` (
+  `f1` int(11) NOT NULL
+)
+mysqld-bin.000002	#	Xid	#	#	COMMIT /* XID */
+connection node_2;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000003	#	Gtid	#	#	BEGIN GTID #-#-#
+mysqld-bin.000003	#	Query	#	#	use `test`; CREATE TABLE `ts1` (
+  `f1` int(11) NOT NULL
+)
+mysqld-bin.000003	#	Query	#	#	COMMIT
+BINLOG_POSITIONS_MATCH
+1
+DROP TABLE t1,ts1;

--- a/mysql-test/suite/galera/r/galera_as_master.result
+++ b/mysql-test/suite/galera/r/galera_as_master.result
@@ -52,6 +52,8 @@ DROP TABLE t1, t4;
 SET SQL_LOG_BIN=OFF;
 DROP TABLE t2, t3;
 connection node_3;
+BINLOG_POSITIONS_MATCH
+1
 STOP SLAVE;
 RESET SLAVE ALL;
 CALL mtr.add_suppression('You need to use --log-bin to make --binlog-format work');

--- a/mysql-test/suite/galera/t/MDEV-27806.opt
+++ b/mysql-test/suite/galera/t/MDEV-27806.opt
@@ -1,0 +1,1 @@
+--log-bin --log-slave-updates --gtid-strict-mode --wsrep_gtid_mode=on

--- a/mysql-test/suite/galera/t/MDEV-27806.test
+++ b/mysql-test/suite/galera/t/MDEV-27806.test
@@ -1,0 +1,49 @@
+#
+# MDEV-27806 GTIDs diverge after CTAS
+#
+--source include/galera_cluster.inc
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+CREATE TABLE ts1 AS SELECT * FROM t1;
+--let binlog_pos= `SELECT @@gtid_binlog_pos`
+
+--let $MASTER_MYPORT=$NODE_MYPORT_1
+--let $binlog_file=LAST
+--let $binlog_limit=8,20
+--source include/show_binlog_events.inc
+
+--connection node_2
+--let $binlog_limit=7,20
+--source include/show_binlog_events.inc
+
+--disable_query_log
+--eval SELECT STRCMP(@@gtid_binlog_pos, "$binlog_pos") = 0 AS BINLOG_POSITIONS_MATCH;
+--enable_query_log
+
+DROP TABLE t1,ts1;
+
+
+#
+# Same as above, with empty CREATE TABLE AS SELECT
+#
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE ts1 AS SELECT * FROM t1;
+--let binlog_pos= `SELECT @@gtid_binlog_pos`
+
+--let $MASTER_MYPORT=$NODE_MYPORT_1
+--let $binlog_file=LAST
+--let $binlog_limit=18,20
+--source include/show_binlog_events.inc
+
+--connection node_2
+--let $binlog_limit=17,20
+--source include/show_binlog_events.inc
+
+--disable_query_log
+--eval SELECT STRCMP(@@gtid_binlog_pos, "$binlog_pos") = 0 AS BINLOG_POSITIONS_MATCH;
+--enable_query_log
+
+DROP TABLE t1,ts1;

--- a/mysql-test/suite/galera/t/galera_as_master.test
+++ b/mysql-test/suite/galera/t/galera_as_master.test
@@ -52,11 +52,17 @@ DROP TABLE t1, t4;
 SET SQL_LOG_BIN=OFF;
 DROP TABLE t2, t3;
 
+--let binlog_pos=`SELECT @@gtid_binlog_pos;`
+
 --connection node_3
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't4';
 --source include/wait_condition.inc
+
+--disable_query_log
+--eval SELECT STRCMP(@@gtid_binlog_pos, "$binlog_pos") = 0 AS BINLOG_POSITIONS_MATCH;
+--enable_query_log
 
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -196,6 +196,11 @@ int wsrep_apply_events(THD*        thd,
       (thd->variables.option_bits & ~OPTION_SKIP_REPLICATION) |
       (ev->flags & LOG_EVENT_SKIP_REPLICATION_F ?  OPTION_SKIP_REPLICATION : 0);
 
+    if (ev->get_type_code() == GTID_EVENT)
+    {
+      thd->variables.option_bits &= ~OPTION_GTID_BEGIN;
+    }
+
     ev->thd= thd;
     exec_res= ev->apply_event(thd->wsrep_rgi);
     DBUG_PRINT("info", ("exec_event result: %d", exec_res));

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -534,6 +534,7 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta& ws_meta,
   THD* thd= m_thd;
 
   thd->variables.option_bits |= OPTION_BEGIN;
+  thd->variables.option_bits |= OPTION_GTID_BEGIN;
   thd->variables.option_bits |= OPTION_NOT_AUTOCOMMIT;
   DBUG_ASSERT(thd->wsrep_trx().active());
   DBUG_ASSERT(thd->wsrep_trx().state() == wsrep::transaction::s_executing);
@@ -570,6 +571,8 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta& ws_meta,
     thd->wsrep_cs().fragment_applied(ws_meta.seqno());
   }
   thd_proc_info(thd, "wsrep applied write set");
+
+  thd->variables.option_bits &= ~OPTION_GTID_BEGIN;
   DBUG_RETURN(ret);
 }
 


### PR DESCRIPTION
Add OPTION_GTID_BEGIN to applying side thd. This is needed to avoid
intermediate commits when CREATE TABLE AS SELECT is applied, causing
one more GTID to be consumed with respect to executing node.