### PR TITLE
MDEV-33064: Sync trx->wsrep state from THD on trx start 

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-33064.result
+++ b/mysql-test/suite/galera/r/MDEV-33064.result
@@ -1,0 +1,25 @@
+connection node_2;
+connection node_1;
+connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1;
+CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t1_fk(c1 INT PRIMARY KEY, c2 INT, INDEX (c2), FOREIGN KEY (c2) REFERENCES t1(c1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection con1;
+SET DEBUG_SYNC = 'ib_after_row_insert SIGNAL may_alter WAIT_FOR bf_abort';
+INSERT INTO t1_fk VALUES (1, 1);
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+SET DEBUG_SYNC = 'lock_wait_end WAIT_FOR alter_continue';
+ALTER TABLE t1 ADD COLUMN c2 INT, ALGORITHM=INPLACE;
+connection con1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = 'now SIGNAL alter_continue';
+connection node_1;
+connection node_2;
+INSERT INTO t1 (c1, c2) VALUES (2, 2);
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1_fk, t1;
+disconnect con1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-33064.cnf
+++ b/mysql-test/suite/galera/t/MDEV-33064.cnf
@@ -1,0 +1,5 @@
+!include ../galera_2nodes.cnf
+
+# Disable retry for autocommit statements.
+[mysqld]
+wsrep-retry-autocommit=0

--- a/mysql-test/suite/galera/t/MDEV-33064.test
+++ b/mysql-test/suite/galera/t/MDEV-33064.test
@@ -1,0 +1,58 @@
+#
+# MDEV-33064: ALTER INPLACE running TOI should abort a conflicting DML operation
+#
+# DDL operations may commit InnoDB transactions more than once during the execution.
+# In this case wsrep flag on trx object is cleared, which may cause wrong logic of
+# such operations afterwards (wsrep-related hooks are not run).
+# One of the consequences was that DDL operation couldn't abort a DML operation
+# holding conflicting locks.
+#
+# The fix: re-enable wsrep flag on trx restart if it's a part of a DDL operation.
+#
+# The test runs with autocommit statement retry disabled.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t1_fk(c1 INT PRIMARY KEY, c2 INT, INDEX (c2), FOREIGN KEY (c2) REFERENCES t1(c1)) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (1);
+
+--connection con1
+SET DEBUG_SYNC = 'ib_after_row_insert SIGNAL may_alter WAIT_FOR bf_abort';
+# INSERT also grabs FK-referenced table lock.
+--send
+  INSERT INTO t1_fk VALUES (1, 1);
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+SET DEBUG_SYNC = 'lock_wait_end WAIT_FOR alter_continue';
+# ALTER BF-aborts INSERT.
+--send
+  ALTER TABLE t1 ADD COLUMN c2 INT, ALGORITHM=INPLACE;
+
+--connection con1
+# INSERT gets BF-aborted.
+--error ER_LOCK_DEADLOCK
+--reap
+SET DEBUG_SYNC = 'now SIGNAL alter_continue';
+
+--connection node_1
+# ALTER succeeds.
+--reap
+
+--connection node_2
+# Sanity check that ALTER has been replicated.
+INSERT INTO t1 (c1, c2) VALUES (2, 2);
+
+# Cleanup.
+--connection node_1
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1_fk, t1;
+--disconnect con1
+--source include/galera_end.inc

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -918,6 +918,9 @@ trx_start_low(
 
 #ifdef WITH_WSREP
 	trx->xid.null();
+	/* Transactions may be reused after commit, where wsrep state flag
+	gets reset. Sync it again from the corresponding THD object. */
+	trx->wsrep = wsrep_on(trx->mysql_thd);
 #endif /* WITH_WSREP */
 
 	ut_a(ib_vector_is_empty(trx->autoinc_locks));
@@ -1483,6 +1486,10 @@ TRANSACTIONAL_INLINE inline void trx_t::commit_in_memory(const mtr_t *mtr)
     trx_finalize_for_fts(this, undo_no != 0);
 
 #ifdef WITH_WSREP
+  /* Sanity check that wsrep state flags match for the transaction
+   * and its corresponding THD object. */
+  ut_ad(is_wsrep() == wsrep_on(mysql_thd));
+
   /* Serialization history has been written and the transaction is
   committed in memory, which makes this commit ordered. Release commit
   order critical section. */


### PR DESCRIPTION
InnoDB transactions may be reused after committed:
- when taken from the transaction pool
- during a DDL operation execution

In this case wsrep flag on trx object is cleared, which may cause wrong
execution logic afterwards (wsrep-related hooks are not run).