### PR TITLE
MDEV-33540 Avoid writes to TRX_SYS page during mariabackup operations

### DIFF
--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -207,6 +207,11 @@ bool trx_rseg_read_wsrep_checkpoint(const trx_rsegf_t* rseg_header, XID& xid)
 @return	whether the WSREP XID is present */
 static bool trx_rseg_init_wsrep_xid(const page_t* page, XID& xid)
 {
+	if (memcmp(TRX_SYS + TRX_SYS_WSREP_XID_INFO + page,
+		           field_ref_zero, TRX_SYS_WSREP_XID_LEN) == 0) {
+		return false;
+	}
+
 	if (mach_read_from_4(TRX_SYS + TRX_SYS_WSREP_XID_INFO
 			     + TRX_SYS_WSREP_XID_MAGIC_N_FLD
 			     + page)
@@ -570,10 +575,6 @@ static void trx_rseg_init_binlog_info(const page_t* page)
 			+ TRX_SYS + page);
 		trx_sys.recovered_binlog_is_legacy_pos= true;
 	}
-
-#ifdef WITH_WSREP
-	trx_rseg_init_wsrep_xid(page, trx_sys.recovered_wsrep_xid);
-#endif
 }
 
 /** Initialize or recover the rollback segments at startup. */
@@ -605,7 +606,11 @@ dberr_t trx_rseg_array_init()
 					+ sys->frame);
 				trx_rseg_init_binlog_info(sys->frame);
 #ifdef WITH_WSREP
-				wsrep_sys_xid.set(&trx_sys.recovered_wsrep_xid);
+				if (trx_rseg_init_wsrep_xid(
+					    sys->frame, trx_sys.recovered_wsrep_xid)) {
+					wsrep_sys_xid.set(
+						&trx_sys.recovered_wsrep_xid);
+				}
 #endif
 			}
 
@@ -662,7 +667,7 @@ dberr_t trx_rseg_array_init()
 	}
 
 #ifdef WITH_WSREP
-	if (!wsrep_sys_xid.is_null()) {
+	if (srv_operation == SRV_OPERATION_NORMAL && !wsrep_sys_xid.is_null()) {
 		/* Upgrade from a version prior to 10.3.5,
 		where WSREP XID was stored in TRX_SYS page.
 		If no rollback segment has a WSREP XID set,


### PR DESCRIPTION
Fix a scenario where `mariabackup --prepare` fails with assertion `!m_modifications || !recv_no_log_write'  in `mtr_t::commit()`. This happens if the prepare step of the backup encounters a data directory which happens to store wsrep xid position in TRX SYS page (this is no longer the case since 10.3.5). And since MDEV-17458, `trx_rseg_array_init()` handles this case by copying the xid position to rollback segments, before clearing the xid from TRX SYS page. However, this step should be avoided when `trx_rseg_array_init()` is invoked from mariabackup. The relevant code was surrounded by the condition `srv_operation == SRV_OPERATION_NORMAL`. An additional check ensures that we are not trying to copy a xid position which has already zeroed.