### PR TITLE
MDEV-32974 : Member fails to join due to old seqno in GTID

### DIFF
--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -34,6 +34,7 @@ Created 3/26/1996 Heikki Tuuri
 
 #ifdef WITH_WSREP
 # include <mysql/service_wsrep.h>
+#include <string>
 
 /** The offset to WSREP XID headers, after TRX_RSEG */
 # define TRX_RSEG_WSREP_XID_INFO      TRX_RSEG_MAX_TRX_ID + 16 + 512
@@ -201,7 +202,7 @@ bool trx_rseg_read_wsrep_checkpoint(const buf_block_t *rseg_header, XID &xid)
 	memcpy(xid.data, TRX_RSEG + TRX_RSEG_WSREP_XID_DATA
 	       + rseg_header->page.frame, XIDDATASIZE);
 
-	return true;
+	return (wsrep_is_wsrep_xid(&xid));
 }
 
 /** Read the WSREP XID from the TRX_SYS page (in case of upgrade).
@@ -232,7 +233,8 @@ static bool trx_rseg_init_wsrep_xid(const page_t* page, XID& xid)
 	memcpy(xid.data,
 	       TRX_SYS + TRX_SYS_WSREP_XID_INFO
 	       + TRX_SYS_WSREP_XID_DATA + page, XIDDATASIZE);
-	return true;
+
+	return (wsrep_is_wsrep_xid(&xid));
 }
 
 /** Recover the latest WSREP checkpoint XID.
@@ -493,10 +495,19 @@ static dberr_t trx_rseg_mem_restore(trx_rseg_t *rseg, mtr_t *mtr)
           trx_sys.recovered_binlog_offset= binlog_offset;
         trx_sys.recovered_binlog_is_legacy_pos= false;
       }
-#ifdef WITH_WSREP
-      trx_rseg_read_wsrep_checkpoint(rseg_hdr, trx_sys.recovered_wsrep_xid);
-#endif
     }
+#ifdef WITH_WSREP
+    XID tmp_xid;
+    tmp_xid.null();
+    /* Update recovered wsrep xid only if we found wsrep xid from
+       rseg header page and read xid seqno is larger than currently
+       recovered xid seqno. */
+    if (trx_rseg_read_wsrep_checkpoint(rseg_hdr, tmp_xid) &&
+        wsrep_xid_seqno(&tmp_xid) > wsrep_xid_seqno(&trx_sys.recovered_wsrep_xid))
+    {
+      trx_sys.recovered_wsrep_xid.set(&tmp_xid);
+    }
+#endif
   }
 
   if (srv_operation == SRV_OPERATION_RESTORE)


### PR DESCRIPTION
Before MDEV-15158, wsrep xid information was stored in only one place: in the TRX_SYS page. Starting with 10.3, it is not stored there but in the rollback segment header pages, and the latest one is what matters. MDEV-19229 allows the undo tablespaces to be rebuilt when innodb_undo_tablespaces is changed on startup. Previously it was not possible to change that parameter.

These changes caused the fact that rollback segment header pages could contain several wsrep xid's storead and when undo tablespaces were rebuilt there was a effort to restore wsrep xid back to rollback segment header page but because there was several of them the latest wsrep xid was overwritten with more older one.

trx_rseg_read_wsrep_checkpoint
trx_rseg_init_wsrep_xid
	Return true if read xid is wsrep xid, false if not

trx_rseg_mem_restore
	Try to read wsrep xid and if it is found copy it to
	rx_sys.recovered_wsrep_xid if read xid has larger seqno.