### PR TITLE
MDEV-33749 hyphen in table name can cause galera certification failures

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -55,7 +55,7 @@ extern struct wsrep_service_st {
   long long                   (*wsrep_xid_seqno_func)(const struct xid_t *xid);
   const unsigned char*        (*wsrep_xid_uuid_func)(const struct xid_t *xid);
   my_bool                     (*wsrep_on_func)(const MYSQL_THD thd);
-  bool                        (*wsrep_prepare_key_for_innodb_func)(MYSQL_THD thd, const unsigned char*, size_t, const unsigned char*, size_t, struct wsrep_buf*, size_t*);
+  bool                        (*wsrep_prepare_key_for_innodb_func)(MYSQL_THD thd, const unsigned char*, size_t, const unsigned char*, size_t, struct wsrep_buf*, size_t*, char*);
   void                        (*wsrep_thd_LOCK_func)(const MYSQL_THD thd);
   int                         (*wsrep_thd_TRYLOCK_func)(const MYSQL_THD thd);
   void                        (*wsrep_thd_UNLOCK_func)(const MYSQL_THD thd);
@@ -110,7 +110,7 @@ extern struct wsrep_service_st {
 #define wsrep_xid_seqno(X) wsrep_service->wsrep_xid_seqno_func(X)
 #define wsrep_xid_uuid(X) wsrep_service->wsrep_xid_uuid_func(X)
 #define wsrep_on(thd) (thd) && WSREP_ON && wsrep_service->wsrep_on_func(thd)
-#define wsrep_prepare_key_for_innodb(A,B,C,D,E,F,G) wsrep_service->wsrep_prepare_key_for_innodb_func(A,B,C,D,E,F,G)
+#define wsrep_prepare_key_for_innodb(A,B,C,D,E,F,G,H) wsrep_service->wsrep_prepare_key_for_innodb_func(A,B,C,D,E,F,G,H)
 #define wsrep_thd_LOCK(T) wsrep_service->wsrep_thd_LOCK_func(T)
 #define wsrep_thd_TRYLOCK(T) wsrep_service->wsrep_thd_TRYLOCK_func(T)
 #define wsrep_thd_UNLOCK(T) wsrep_service->wsrep_thd_UNLOCK_func(T)
@@ -158,7 +158,7 @@ extern my_bool wsrep_recovery;
 extern long wsrep_protocol_version;
 
 extern "C" bool wsrep_consistency_check(MYSQL_THD thd);
-bool wsrep_prepare_key_for_innodb(MYSQL_THD thd, const unsigned char* cache_key, size_t cache_key_len, const unsigned char* row_id, size_t row_id_len, struct wsrep_buf* key, size_t* key_len);
+bool wsrep_prepare_key_for_innodb(MYSQL_THD thd, const unsigned char* cache_key, size_t cache_key_len, const unsigned char* row_id, size_t row_id_len, struct wsrep_buf* key, size_t* key_len, char* result_key);
 extern "C" const char *wsrep_thd_query(const MYSQL_THD thd);
 extern "C" int wsrep_is_wsrep_xid(const void* xid);
 extern "C" long long wsrep_xid_seqno(const struct xid_t* xid);

--- a/mysql-test/suite/galera/r/galera_table_with_hyphen.result
+++ b/mysql-test/suite/galera/r/galera_table_with_hyphen.result
@@ -1,0 +1,37 @@
+connection node_2;
+connection node_1;
+connection node_1;
+set wsrep_sync_wait=0;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE `par-ent` (
+id INT AUTO_INCREMENT  PRIMARY KEY,
+j INT
+) ENGINE=InnoDB;
+CREATE TABLE child (
+id INT AUTO_INCREMENT PRIMARY KEY, 
+parent_id INT,
+j INT,
+FOREIGN KEY (parent_id) 
+REFERENCES `par-ent`(id)
+ON DELETE CASCADE
+) ENGINE=InnoDB;
+INSERT INTO `par-ent` VALUES (23,0);
+connection node_2;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL DEBUG_DBUG='+d,wsrep_ha_write_row';
+connection node_2;
+INSERT INTO child VALUES (21,23,0),(22,23,0),(23,23,0);
+connection node_1a;
+SET DEBUG_SYNC='now WAIT_FOR  wsrep_ha_write_row_reached';
+connection node_2;
+UPDATE `par-ent` SET j=2 WHERE id=23;
+connection node_1a;
+SET GLOBAL DEBUG_DBUG='-d,wsrep_ha_write_row';
+SET DEBUG_SYNC='now SIGNAL wsrep_ha_write_row_continue';
+connection node_1;
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+SET GLOBAL DEBUG_DBUG="RESET";
+connection node_2;
+drop table child;
+drop table `par-ent`;

--- a/mysql-test/suite/galera/t/galera_table_with_hyphen.test
+++ b/mysql-test/suite/galera/t/galera_table_with_hyphen.test
@@ -1,0 +1,60 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--connection node_1
+set wsrep_sync_wait=0;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE `par-ent` (
+    id INT AUTO_INCREMENT  PRIMARY KEY,
+    j INT
+) ENGINE=InnoDB;
+
+CREATE TABLE child (
+    id INT AUTO_INCREMENT PRIMARY KEY, 
+    parent_id INT,
+    j INT,
+    FOREIGN KEY (parent_id) 
+        REFERENCES `par-ent`(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+INSERT INTO `par-ent` VALUES (23,0);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM `par-ent`;
+--source include/wait_condition.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL DEBUG_DBUG='+d,wsrep_ha_write_row';
+
+--connection node_2
+INSERT INTO child VALUES (21,23,0),(22,23,0),(23,23,0);
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR  wsrep_ha_write_row_reached';
+
+--let $wsrep_received_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_received'`
+
+--connection node_2
+UPDATE `par-ent` SET j=2 WHERE id=23;
+
+--connection node_1a
+--sleep 2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_received_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_received'
+--source include/wait_condition.inc
+
+SET GLOBAL DEBUG_DBUG='-d,wsrep_ha_write_row';
+SET DEBUG_SYNC='now SIGNAL wsrep_ha_write_row_continue';
+
+--connection node_1
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+
+SET GLOBAL DEBUG_DBUG="RESET";
+
+--connection node_2
+drop table child;
+drop table `par-ent`;
+

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7635,7 +7635,16 @@ int handler::ha_write_row(const uchar *buf)
               m_lock_type == F_WRLCK);
   DBUG_ENTER("handler::ha_write_row");
   DEBUG_SYNC_C("ha_write_row_start");
-
+#ifdef WITH_WSREP
+  DBUG_EXECUTE_IF("wsrep_ha_write_row",
+                  {
+                    const char act[]=
+                      "now "
+                      "SIGNAL wsrep_ha_write_row_reached "
+                      "WAIT_FOR wsrep_ha_write_row_continue";
+                    DBUG_ASSERT(!debug_sync_set_action(ha_thd(), STRING_WITH_LEN(act)));
+                  });
+#endif /* WITH_WSREP */
   if ((error= ha_check_overlaps(NULL, buf)))
     DBUG_RETURN(error);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9881,6 +9881,7 @@ wsrep_append_foreign_key(
 
 	ulint rcode = DB_SUCCESS;
 	char  cache_key[513] = {'\0'};
+	char  result_cache_key[513] = {'\0'};
 	size_t cache_key_len = 0;
 
 	if ( !((referenced) ?
@@ -10000,15 +10001,11 @@ wsrep_append_foreign_key(
 	wsrep_buf_t wkey_part[3];
         wsrep_key_t wkey = {wkey_part, 3};
 
-	if (!wsrep_prepare_key_for_innodb(
-		thd,
-		(const uchar*)cache_key,
-		cache_key_len +  1,
-		(const uchar*)key, len+1,
-		wkey_part,
-		(size_t*)&wkey.key_parts_num)) {
+	if (!wsrep_prepare_key_for_innodb(thd, (const uchar*)cache_key,
+		cache_key_len +  1, (const uchar*)key, len+1,wkey_part,
+		(size_t*)&wkey.key_parts_num, result_cache_key)) {
 		WSREP_WARN("key prepare failed for cascaded FK: %s",
-			   wsrep_thd_query(thd));
+			wsrep_thd_query(thd));
 		return DB_ERROR;
 	}
 
@@ -10066,7 +10063,8 @@ wsrep_append_key(
 			table_share->table_cache_key.length,
 			(const uchar*)key, key_len,
 			wkey_part,
-			(size_t*)&wkey.key_parts_num)) {
+			(size_t*)&wkey.key_parts_num,
+                        nullptr)) {
 		WSREP_WARN("key prepare failed for: %s",
 			   (wsrep_thd_query(thd)) ?
 			   wsrep_thd_query(thd) : "void");


### PR DESCRIPTION
Fix in this commit handles foreign key value appending into write set so that db and table valus are converted from the filepath format to tablename format. This is compatible with key values appended from other part of code base