### PR TITLE
MDEV-33997 : Assertion `((WSREP_PROVIDER_EXISTS_ && this->variables.w…

### DIFF
--- a/mysql-test/suite/wsrep/r/MDEV-33997.result
+++ b/mysql-test/suite/wsrep/r/MDEV-33997.result
@@ -1,0 +1,38 @@
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+c
+1
+1
+DROP TABLE t;
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+c
+1
+DROP TABLE t;
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+ERROR 42000: This version of MariaDB doesn't yet support 'RSU on this table engine'
+SELECT * FROM t;
+c
+DROP TABLE t;
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+ERROR 42000: This version of MariaDB doesn't yet support 'RSU on this table engine'
+COMMIT;
+SELECT * FROM t;
+c
+1
+DROP TABLE t;

--- a/mysql-test/suite/wsrep/t/MDEV-33997.cnf
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.cnf
@@ -1,0 +1,9 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+binlog-format=ROW
+innodb-flush-log-at-trx-commit=1
+wsrep-cluster-address=gcomm://
+wsrep-provider=@ENV.WSREP_PROVIDER
+innodb-autoinc-lock-mode=2

--- a/mysql-test/suite/wsrep/t/MDEV-33997.combinations
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.combinations
@@ -1,0 +1,4 @@
+[binlogon]
+log-bin
+
+[binlogoff]

--- a/mysql-test/suite/wsrep/t/MDEV-33997.test
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.test
@@ -1,0 +1,49 @@
+--source include/have_wsrep.inc
+--source include/have_innodb.inc
+--source include/have_wsrep_provider.inc
+--source include/have_partition.inc
+#
+# MDEV-33997: Assertion `((WSREP_PROVIDER_EXISTS_ && this->variables.wsrep_on) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed in int THD::binlog_write_row(TABLE*, bool, const uchar*)
+#
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+DROP TABLE t;
+
+#
+# MDEV-27296 : Assertion `((thd && (WSREP_PROVIDER_EXISTS_ && thd->variables.wsrep_on)) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed
+# Second test case
+#
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+DROP TABLE t;
+
+#
+# We should not allow RSU for MyISAM
+#
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+DROP TABLE t;
+
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+DROP TABLE t;

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -5495,13 +5495,15 @@ int Rows_log_event::do_apply_event(rpl_group_info *rgi)
 #ifdef WITH_WSREP
       if (WSREP(thd))
       {
-        WSREP_WARN("BF applier failed to open_and_lock_tables: %u, fatal: %d "
+        WSREP_WARN("BF applier thread=%lu failed to open_and_lock_tables for "
+                   "%s, fatal: %d "
                    "wsrep = (exec_mode: %d conflict_state: %d seqno: %lld)",
-                    thd->get_stmt_da()->sql_errno(),
-                    thd->is_fatal_error,
-                    thd->wsrep_cs().mode(),
-                    thd->wsrep_trx().state(),
-                    (long long) wsrep_thd_trx_seqno(thd));
+                   thd_get_thread_id(thd),
+                   thd->get_stmt_da()->message(),
+                   thd->is_fatal_error,
+                   thd->wsrep_cs().mode(),
+                   thd->wsrep_trx().state(),
+                   wsrep_thd_trx_seqno(thd));
       }
 #endif /* WITH_WSREP */
       if (thd->is_error() &&


### PR DESCRIPTION
…srep_on) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed in int THD::binlog_write_row(TABLE*, bool, const uchar*)

Problem was that we did try to write binlog while in RSU that will pause the node and execute CREATE TABLE only locally in the node.

Fix is to avoid write to binlog if wsrep binlog emulation is disabled or binlog is not open.

If binary log is used and  you next insert into the able, all other nodes will start inconsistency voting and drop from cluster because they do not find table where insert is done.