### PR TITLE
MDEV-31658 : Deadlock found when trying to get lock; try restarting t…

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_duplicate_primary_value.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_duplicate_primary_value.result
@@ -1,0 +1,68 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1c, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1d, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1e, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
+CREATE TABLE t1(a int not null primary key auto_increment, b int) engine=innodb;
+INSERT INTO t1(b) VALUES (1);
+connection node_1c;
+begin;
+insert into t1 values (2,2);
+connection node_1d;
+begin;
+insert into t1 values (3,3);
+connection node_1a;
+SET GLOBAL DEBUG_DBUG='+d,wsrep_after_kill';
+connection node_2;
+insert into t1 values (2,6);
+connection node_1a;
+SET SESSION wsrep_sync_wait=0;
+SET DEBUG_SYNC='now WAIT_FOR wsrep_after_kill_reached';
+SET GLOBAL DEBUG_DBUG='';
+SET GLOBAL DEBUG_DBUG='+d,wsrep_after_kill_2';
+connection node_3;
+insert into t1 values (3,9);
+connection node_1a;
+SET DEBUG_SYNC='now WAIT_FOR wsrep_after_kill_reached_2';
+SET GLOBAL DEBUG_DBUG='';
+SET DEBUG_SYNC='now SIGNAL wsrep_after_kill_continue';
+connection node_1c;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1a;
+SET GLOBAL DEBUG_DBUG='';
+SET DEBUG_SYNC='now SIGNAL wsrep_after_kill_continue_2';
+connection node_1d;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_2;
+SELECT * from t1;
+a	b
+1	1
+2	6
+3	9
+connection node_3;
+SELECT * from t1;
+a	b
+1	1
+2	6
+3	9
+connection node_1a;
+SET DEBUG_SYNC = reset;
+connection node_1e;
+set debug_sync = reset;
+connection node_1;
+SELECT * from t1;
+a	b
+1	1
+2	6
+3	9
+disconnect node_1a;
+disconnect node_1b;
+disconnect node_1c;
+disconnect node_1d;
+disconnect node_1e;
+drop table t1;

--- a/mysql-test/suite/galera_3nodes/t/galera_duplicate_primary_value.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_duplicate_primary_value.cnf
@@ -1,0 +1,19 @@
+!include ../galera_3nodes.cnf
+
+[mysqld.1]
+wsrep-debug=SERVER
+loose-wsrep-duplicate-primary-value=1
+wsrep-auto-increment-control=OFF
+auto-increment-offset=1
+
+[mysqld.2]
+wsrep-debug=SERVER
+loose-wsrep-duplicate-primary-value=1
+wsrep-auto-increment-control=OFF
+auto-increment-offset=1
+
+[mysqld.3]
+wsrep-debug=SERVER
+loose-wsrep-duplicate-primary-value=1
+wsrep-auto-increment-control=OFF
+auto-increment-offset=1

--- a/mysql-test/suite/galera_3nodes/t/galera_duplicate_primary_value.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_duplicate_primary_value.test
@@ -1,0 +1,81 @@
+--source include/galera_cluster.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/big_test.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1c, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1d, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1e, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+--connection node_1
+CREATE TABLE t1(a int not null primary key auto_increment, b int) engine=innodb;
+INSERT INTO t1(b) VALUES (1);
+
+--connection node_1c
+begin;
+insert into t1 values (2,2);
+
+--connection node_1d
+begin;
+insert into t1 values (3,3);
+
+--connection node_1a
+SET GLOBAL DEBUG_DBUG='+d,wsrep_after_kill';
+
+--connection node_2
+insert into t1 values (2,6);
+
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+SET DEBUG_SYNC='now WAIT_FOR wsrep_after_kill_reached';
+SET GLOBAL DEBUG_DBUG='';
+SET GLOBAL DEBUG_DBUG='+d,wsrep_after_kill_2';
+
+--connection node_3
+insert into t1 values (3,9);
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR wsrep_after_kill_reached_2';
+SET GLOBAL DEBUG_DBUG='';
+SET DEBUG_SYNC='now SIGNAL wsrep_after_kill_continue';
+
+--connection node_1c
+--error 1213
+COMMIT;
+
+--connection node_1a
+SET GLOBAL DEBUG_DBUG='';
+SET DEBUG_SYNC='now SIGNAL wsrep_after_kill_continue_2';
+
+--connection node_1d
+--error 1213
+COMMIT;
+
+--connection node_2
+SELECT * from t1;
+
+--connection node_3
+SELECT * from t1;
+
+--connection node_1a
+SET DEBUG_SYNC = reset;
+
+--connection node_1e
+set debug_sync = reset;
+
+--connection node_1
+SELECT * from t1;
+
+--disconnect node_1a
+--disconnect node_1b
+--disconnect node_1c
+--disconnect node_1d
+--disconnect node_1e
+
+drop table t1;

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -249,18 +249,26 @@ extern "C" my_bool wsrep_thd_skip_locking(const THD *thd)
 
 extern "C" my_bool wsrep_thd_order_before(const THD *left, const THD *right)
 {
+  my_bool before=FALSE;
+
   if (wsrep_thd_is_BF(left, false) &&
       wsrep_thd_is_BF(right, false) &&
-      wsrep_thd_trx_seqno(left) < wsrep_thd_trx_seqno(right)) {
-    WSREP_DEBUG("BF conflict, order: %lld %lld\n",
-                (long long)wsrep_thd_trx_seqno(left),
-                (long long)wsrep_thd_trx_seqno(right));
-    return TRUE;
-  }
-  WSREP_DEBUG("waiting for BF, trx order: %lld %lld\n",
-              (long long)wsrep_thd_trx_seqno(left),
-              (long long)wsrep_thd_trx_seqno(right));
-  return FALSE;
+      wsrep_thd_trx_seqno(left) < wsrep_thd_trx_seqno(right))
+    before= TRUE;
+  
+  WSREP_DEBUG("wsrep_thd_order_before: %s thread=%llu seqno=%llu query=%s "
+              "%s %s thread=%llu, seqno=%llu query=%s",
+              (wsrep_thd_is_BF(left, false) ? "BF" : "def"),
+              thd_get_thread_id(left),
+              wsrep_thd_trx_seqno(left),
+              wsrep_thd_query(left),
+              (before ? " TRUE " : " FALSE "),
+              (wsrep_thd_is_BF(right, false) ? "BF" : "def"),
+              thd_get_thread_id(right),
+              wsrep_thd_trx_seqno(right),
+              wsrep_thd_query(right));
+
+  return before;
 }
 
 /** Check if wsrep transaction is aborting state.

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18721,6 +18721,25 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
     wsrep_thd_UNLOCK(vthd);
     wsrep_thd_kill_UNLOCK(vthd);
   }
+
+#ifdef ENABLED_DEBUG_SYNC
+    DBUG_EXECUTE_IF(
+        "wsrep_after_kill",
+        {const char act[]=
+             "now "
+             "SIGNAL wsrep_after_kill_reached "
+             "WAIT_FOR wsrep_after_kill_continue";
+          DBUG_ASSERT(!debug_sync_set_action(bf_thd, STRING_WITH_LEN(act)));
+        };);
+    DBUG_EXECUTE_IF(
+        "wsrep_after_kill_2",
+        {const char act2[]=
+             "now "
+             "SIGNAL wsrep_after_kill_reached_2 "
+             "WAIT_FOR wsrep_after_kill_continue_2";
+          DBUG_ASSERT(!debug_sync_set_action(bf_thd, STRING_WITH_LEN(act2)));
+        };);
+#endif /* ENABLED_DEBUG_SYNC*/
 }
 
 /** This function forces the victim transaction to abort. Aborting the


### PR DESCRIPTION
…ransaction, Error_code: 1213; handler error HA_ERR_LOCK_DEADLOCK; the event's master log FIRST, end_log_pos xxx, Internal MariaDB error code: 1213

Problem was that there was two non-conflicting local idle transactions in node_1 that both inserted a key to primary key. Then two transactions from other nodes inserted also a key to primary key so that insert from node_2 conflicted one of the local transactions in node_1 so that there would be duplicate key if both are committed. For this insert from other node tries to acquire S-lock for this record and because this insert is high priority brute force (BF) transaction it will kill idle local transaction.

Concurrently, second insert from node_3 conflicts the second idle insert transaction in node_1. Again, it tries to acquire S-lock for this record and kills idle local transaction.

At this point we have two non-conflicting high priority transactions holding S-lock on different records in node_1. For example like this: rec s-lock-node2-rec s-lock-node3-rec rec.

Because these high priority BF-transactions do not wait each other insert from node3 that has later seqno compared to insert from node2 can continue. It will try to acquire insert intention for record it tries to insert (to avoid duplicate key to be inserted by local transaction). Hower, it will note that there is conflicting S-lock in same gap between records. This will lead deadlock error as we have defined that BF-transactions may not wait for record lock but we can't kill conflicting BF-transaction because it has lower seqno and it should commit first.

BF-transactions are executed concurrently because their values to primary key are different i.e. they do not conflict.

Galera certification will make sure that inserts from other nodes i.e these high priority BF-transactions can't insert duplicate keys. Local transactions naturally can but they will be killed when BF-transaction
acquires required record locks.

Therefore, we can allow situation where there is conflicting S-lock and insert intention lock regardless of their seqno order and let both continue with no wait. This will lead to situation where we need to allow BF-transaction to wait when lock_rec_has_to_wait_in_queue is called because this function is also called from
lock_rec_queue_validate and because lock is waiting there would be assertion in ut_a(lock->is_gap()
|| lock_rec_has_to_wait_in_queue(cell, lock));

wsrep_thd_order_before
  Function should be called only for high-priority BF
  transactions and their seqno order is checked.

lock_wait_wsrep_kill
  Add debug sync points for BF-transactions killing
  local transaction.

wsrep_assert_no_bf_bf_wait
  Print also requested lock information

lock_rec_has_to_wait
  Reformat function as we make bigger changes. Add
  clear conditions when wsrep transaction does not
  need to wait.

lock_rec_has_to_wait_in_queue
  Remove wsrep exception, in this contents all
  conflicting locks need to wait in queue.
  Conflicts between BF and local transactions
  are handled in lock_wait.