### PR TITLE
MDEV-34269 : 10.11.8 cluster becomes inconsistent when using composit…

### DIFF
--- a/mysql-test/include/log_bin.combinations
+++ b/mysql-test/include/log_bin.combinations
@@ -1,0 +1,4 @@
+[binlogoff]
+
+[binlogon]
+log-bin

--- a/mysql-test/include/log_bin.inc
+++ b/mysql-test/include/log_bin.inc
@@ -1,0 +1,3 @@
+# include file for test files that can be run with and without log-bin
+# (see include/log_bin.combinations)
+

--- a/mysql-test/suite/galera/r/galera_partition_key.result
+++ b/mysql-test/suite/galera/r/galera_partition_key.result
@@ -1,0 +1,46 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE `t1` (
+`id` int(10) unsigned NOT NULL,
+`other_id` int(10) unsigned NOT NULL,
+PRIMARY KEY (`id`,`other_id`)
+) ENGINE=InnoDB
+PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+INSERT INTO t1 VALUES (1, 0);
+CREATE TABLE t2 LIKE t1;
+START TRANSACTION;
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+COMMIT;
+connection node_2;
+SELECT * from t1;
+id	other_id
+SELECT * from t2;
+id	other_id
+1	0
+DROP TABLE t1, t2;
+connection node_1;
+CREATE TABLE `t1` (
+`id` int(10) unsigned NOT NULL,
+`other_id` int(10) unsigned NOT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+INSERT INTO t1 VALUES (1, 0);
+CREATE TABLE t2 LIKE t1;
+START TRANSACTION;
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+COMMIT;
+connection node_2;
+SELECT * from t1;
+id	other_id
+SELECT * from t2;
+id	other_id
+1	0
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/galera_myisam_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_myisam_autocommit.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/log_bin.inc
 
 #
 # This tests simple autocommit replication of MyISAM tables.

--- a/mysql-test/suite/galera/t/galera_partition.test
+++ b/mysql-test/suite/galera/t/galera_partition.test
@@ -2,6 +2,7 @@
 --source include/have_partition.inc
 --source include/big_test.inc
 --source include/force_restart.inc
+--source include/log_bin.inc
 
 --connection node_1
 

--- a/mysql-test/suite/galera/t/galera_partition_key.test
+++ b/mysql-test/suite/galera/t/galera_partition_key.test
@@ -1,0 +1,55 @@
+--source include/galera_cluster.inc
+--source include/have_partition.inc
+--source include/log_bin.inc
+
+--connection node_1
+CREATE TABLE `t1` (
+  `id` int(10) unsigned NOT NULL,
+  `other_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`,`other_id`)
+) ENGINE=InnoDB
+ PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+ PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+
+INSERT INTO t1 VALUES (1, 0);
+
+CREATE TABLE t2 LIKE t1;
+
+START TRANSACTION;
+
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+
+COMMIT;
+
+--connection node_2
+SELECT * from t1;
+SELECT * from t2;
+DROP TABLE t1, t2;
+
+--connection node_1
+CREATE TABLE `t1` (
+  `id` int(10) unsigned NOT NULL,
+  `other_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+ PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+ PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+
+INSERT INTO t1 VALUES (1, 0);
+
+CREATE TABLE t2 LIKE t1;
+
+START TRANSACTION;
+
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+
+COMMIT;
+
+--connection node_2
+SELECT * from t1;
+SELECT * from t2;
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/mdev-22063.test
+++ b/mysql-test/suite/galera/t/mdev-22063.test
@@ -1,6 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
---source include/have_log_bin.inc
+--source include/log_bin.inc
 --source include/have_sequence.inc
 --source include/have_aria.inc
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4747,7 +4747,9 @@ mysql_execute_command(THD *thd)
 #ifdef WITH_WSREP
       if (wsrep && !first_table->view)
       {
-        bool is_innodb= (first_table->table->file->ht->db_type == DB_TYPE_INNODB);
+        const handlerton *hton = first_table->table->file->partition_ht() ?
+          first_table->table->file->partition_ht() : first_table->table->file->ht;
+        bool is_innodb= (hton->db_type == DB_TYPE_INNODB);
 
         // For consistency check inserted table needs to be InnoDB
         if (!is_innodb && thd->wsrep_consistency_check != NO_CONSISTENCY_CHECK)


### PR DESCRIPTION
…e primary key and partitioning

This is regression from commit 3228c08fa8. Problem is that when table storage engine is determined there should be check is table partitioned and if it is then determine partition implementing storage engine.

Reported bug is reproducible only with --log-bin so make sure tests changed by 3228c08fa8 and new test are run with --log-bin and binlog disabled.