### PR TITLE
MDEV-33035 : Galera test case MDEV-16509 unstable

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-16509.result
+++ b/mysql-test/suite/galera/r/MDEV-16509.result
@@ -28,6 +28,11 @@ wsrep_last_seen_gtid_do_not_match
 1
 SET DEBUG_SYNC = "now SIGNAL after_group_continue";
 connection node_1;
+SELECT * from t1;
+f1
+1
+connection ctrl;
+SET DEBUG_SYNC = "RESET";
 SET SESSION wsrep_sync_wait = 0;
 connection ctrl;
 connection node_1;
@@ -69,6 +74,11 @@ SET DEBUG_SYNC = "now SIGNAL agac_continue_2";
 connection node_1a;
 connection ctrl;
 SET DEBUG_SYNC = "RESET";
+SELECT * from t1;
+f1
+1
+2
+3
 DROP TABLE t1;
 disconnect ctrl;
 disconnect node_1a;

--- a/mysql-test/suite/galera/t/MDEV-16509.test
+++ b/mysql-test/suite/galera/t/MDEV-16509.test
@@ -58,6 +58,12 @@ SET DEBUG_SYNC = "now SIGNAL after_group_continue";
 
 --connection node_1
 --reap
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
+SELECT * from t1;
+
+--connection ctrl
+SET DEBUG_SYNC = "RESET";
 
 #
 # Scenario 2: Verify that two INSERTs from two different connections
@@ -136,6 +142,10 @@ SET DEBUG_SYNC = "now SIGNAL agac_continue_2";
 
 --connection ctrl
 SET DEBUG_SYNC = "RESET";
+
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
+SELECT * from t1;
 
 DROP TABLE t1;
 


### PR DESCRIPTION
Stabilize test by reseting DEBUG_SYNC and add wait_condition for expected table contents.