### PR TITLE
MDEV-35265 wsrep.wsrep-recover, wsrep.wsrep-recover-v25 fail on assertion

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2684,7 +2684,8 @@ static void xarecover_do_commit_or_rollback(handlerton *hton,
 
   if (xarecover_decide_to_commit(member, ptr_commit_max))
     rc= hton->commit_by_xid(hton, &x);
-  else if (hton->recover_rollback_by_xid)
+  else if (hton->recover_rollback_by_xid &&
+           IF_WSREP(!(WSREP_ON || wsrep_recovery), true))
     rc= hton->recover_rollback_by_xid(&x);
   else
     rc= hton->rollback_by_xid(hton, &x);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17211,7 +17211,8 @@ int innobase_recover_rollback_by_xid(const XID *xid)
   ut_ad(trx->state == TRX_STATE_PREPARED);
 
 #ifdef WITH_WSREP
-  ut_ad(!wsrep_is_wsrep_xid(&trx->xid));
+  // prepared transactions must not be rolled back asynchronously when wsrep is on
+  ut_ad(!(WSREP_ON || wsrep_recovery));
 #endif
 
   if (trx->rsegs.m_redo.undo)


### PR DESCRIPTION
The tests fail on assertion

    ut_ad(!wsrep_is_wsrep_xid(&trx->xid));

in `innobase_recover_rollback_by_xid()`.

The fix is to avoid async rollback for prepared transactions
when wsrep is ON or wsrep recovery is in progress. The rationale
is that the rollback of prepared transactions must complete
before the node starts applying write sets after SST, or in
case of wsrep recovery, the recovery must complete before the
process exists.

Change the assertion into stronger one

    ut_ad(!(WSREP_ON || wsrep_recovery));

to catch if the async rollback codepath is taken when wsrep is
enabled.
