### PR TITLE
MDEV-24485 : galera.galera_bf_kill_debug MTR failed: A long semaphore…

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_kill_debug.result
+++ b/mysql-test/suite/galera/r/galera_bf_kill_debug.result
@@ -40,18 +40,19 @@ drop table t1;
 disconnect node_2a;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
-CREATE TABLE t1 (i int primary key);
+CREATE TABLE t1 (i int primary key) engine=innodb;
 SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
 INSERT INTO t1 VALUES (1);
 connection node_2;
 SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
 SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
-SET DEBUG_SYNC='RESET';
 connection node_2a;
 connection node_2;
+SET DEBUG_SYNC='RESET';
 select * from t1;
 i
 1
 disconnect node_2a;
+disconnect node_2b;
 connection node_1;
 drop table t1;

--- a/mysql-test/suite/galera/t/galera_bf_kill_debug.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill_debug.test
@@ -110,7 +110,7 @@ drop table t1;
 --connection node_2a
 --let $connection_id = `SELECT CONNECTION_ID()`
 
-CREATE TABLE t1 (i int primary key);
+CREATE TABLE t1 (i int primary key) engine=innodb;
 
 # Set up sync point
 SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
@@ -129,16 +129,17 @@ SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
 --enable_query_log
 
 SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
-SET DEBUG_SYNC='RESET';
 --connection node_2a
 --error 0,1213
 --reap
 
 --connection node_2
+SET DEBUG_SYNC='RESET';
 # victim was able to complete the INSERT
 select * from t1;
 
 --disconnect node_2a
+--disconnect node_2b
 
 --connection node_1
 drop table t1;


### PR DESCRIPTION
… wait

Test sends a signal to debug_sync and in next command resets debug_sync signals. There is small possibility that sended signal is not yet handled in receiving thread and reset will destroy it causing sync wait timeout.