### PR TITLE
Fixup for MDEV-35446

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1165,8 +1165,7 @@ static bool wsrep_command_no_result(char command)
 {
   return (command == COM_STMT_FETCH            ||
           command == COM_STMT_SEND_LONG_DATA   ||
-          command == COM_STMT_CLOSE            ||
-          command == COM_STMT_PREPARE);
+          command == COM_STMT_CLOSE);
 }
 #endif /* WITH_WSREP */
 #ifndef EMBEDDED_LIBRARY
@@ -2444,13 +2443,23 @@ dispatch_end:
     {
       DEBUG_SYNC(thd, "wsrep_at_dispatch_end_before_result");
     }
-    wsrep_after_command_before_result(thd);
-    if (wsrep_current_error(thd) && !wsrep_command_no_result(command))
+    if (thd->wsrep_cs().state() == wsrep::client_state::s_exec)
     {
-      /* todo: Pass wsrep client state current error to override */
-      wsrep_override_error(thd, wsrep_current_error(thd),
-                           wsrep_current_error_status(thd));
-      WSREP_LOG_THD(thd, "leave");
+      wsrep_after_command_before_result(thd);
+      if (wsrep_current_error(thd) && !wsrep_command_no_result(command))
+      {
+        /* todo: Pass wsrep client state current error to override */
+        wsrep_override_error(thd, wsrep_current_error(thd),
+                             wsrep_current_error_status(thd));
+        WSREP_LOG_THD(thd, "leave");
+      }
+    }
+    else
+    {
+      /* wsrep_after_command_before_result() already called elsewhere
+         or not necessary to call it */
+      assert(thd->wsrep_cs().state() == wsrep::client_state::s_none ||
+             thd->wsrep_cs().state() == wsrep::client_state::s_result);
     }
     if (WSREP(thd))
     {

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -2355,6 +2355,16 @@ static bool check_prepared_statement(Prepared_statement *stmt)
 #ifdef WITH_WSREP
     if (wsrep_sync_wait(thd, sql_command))
       goto error;
+    if (!stmt->is_sql_prepare())
+    {
+      wsrep_after_command_before_result(thd);
+      if (wsrep_current_error(thd))
+      {
+        wsrep_override_error(thd, wsrep_current_error(thd),
+                             wsrep_current_error_status(thd));
+        goto error;
+      }
+    }
 #endif
   switch (sql_command) {
   case SQLCOM_REPLACE:

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1231,35 +1231,7 @@ bool wsrep_sync_wait (THD* thd, uint mask)
       This allows autocommit SELECTs and a first SELECT after SET AUTOCOMMIT=0
       TODO: modify to check if thd has locked any rows.
     */
-    if (thd->wsrep_cs().sync_wait(-1))
-    {
-      const char* msg;
-      int err;
-
-      /*
-        Possibly relevant error codes:
-        ER_CHECKREAD, ER_ERROR_ON_READ, ER_INVALID_DEFAULT, ER_EMPTY_QUERY,
-        ER_FUNCTION_NOT_DEFINED, ER_NOT_ALLOWED_COMMAND, ER_NOT_SUPPORTED_YET,
-        ER_FEATURE_DISABLED, ER_QUERY_INTERRUPTED
-      */
-
-      switch (thd->wsrep_cs().current_error())
-      {
-      case wsrep::e_not_supported_error:
-        msg= "synchronous reads by wsrep backend. "
-          "Please unset wsrep_causal_reads variable.";
-        err= ER_NOT_SUPPORTED_YET;
-        break;
-      default:
-        msg= "Synchronous wait failed.";
-        err= ER_LOCK_WAIT_TIMEOUT; // NOTE: the above msg won't be displayed
-                                   //       with ER_LOCK_WAIT_TIMEOUT
-      }
-
-      my_error(err, MYF(0), msg);
-
-      return true;
-    }
+    return thd->wsrep_cs().sync_wait(-1);
   }
 
   return false;


### PR DESCRIPTION
The previous commit for fixing MDEV-35446 disabled setting Galera errors on COM_STMT_PREPARE commands.
As a side effect, a number of tests were started to fail due to the client receiving different error codes from the ones expected in the test dependending on whether --ps-protocol was used.
Also, in the case of test galera_ftwrl, it was found that it is expected that during COM_STMT_PREPARE command, we may perform a sync wait operation, which can fail with LOCK_WAIT_TIMEOUT error.
The revised fix consists in anticipating the call to wsrep_after_command_before_result(), so that we check for BF aborts or errors during statement prepare, before sending back the statement metadata message to client.