### PR TITLE
CREATE, DROP, ALTER TABLE causes MDL BF-BF conflict

### DIFF
--- a/mysql-test/suite/galera/r/mwb-1789-alter.result
+++ b/mysql-test/suite/galera/r/mwb-1789-alter.result
@@ -1,0 +1,41 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE t1 (
+id INTEGER PRIMARY KEY,
+f2 INTEGER
+);
+CREATE TABLE t2 (
+id INT PRIMARY KEY,
+t1_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t1_id(t1_id),
+CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+CREATE TABLE t3 (
+id INT PRIMARY KEY,
+t2_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t2_id(t2_id)
+);
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+connection node_1;
+ALTER TABLE t3 ADD CONSTRAINT key_t2_id FOREIGN KEY (t2_id)
+REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE;
+connection node_2;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+UPDATE t1 SET f2 = 1 WHERE id=2;
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+DROP TABLE t3, t2, t1;

--- a/mysql-test/suite/galera/r/mwb-1789-create.result
+++ b/mysql-test/suite/galera/r/mwb-1789-create.result
@@ -1,0 +1,40 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE t1 (
+id INTEGER PRIMARY KEY,
+f2 INTEGER
+);
+CREATE TABLE t2 (
+id INT PRIMARY KEY,
+t1_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t1_id(t1_id),
+CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+connection node_1;
+CREATE TABLE t3 (
+id INT PRIMARY KEY,
+t2_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t2_id(t2_id),
+CONSTRAINT key_t2_id FOREIGN KEY (t2_id) REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+connection node_2;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+UPDATE t1 SET f2 = 1 WHERE id=2;
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+DROP TABLE t3, t2, t1;

--- a/mysql-test/suite/galera/r/mwb-1789-drop-fk2.result
+++ b/mysql-test/suite/galera/r/mwb-1789-drop-fk2.result
@@ -1,0 +1,43 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE t1 (
+id INTEGER PRIMARY KEY,
+f2 INTEGER
+);
+CREATE TABLE t2 (
+id INT PRIMARY KEY,
+t1_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t1_id(t1_id),
+CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+CREATE TABLE t3 (
+id INT PRIMARY KEY,
+t2_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t2_id(t2_id),
+CONSTRAINT key_t2_id FOREIGN KEY (t2_id) REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+INSERT INTO t3 VALUES (1,1,1234);
+INSERT INTO t3 VALUES (2,2,1234);
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+connection node_1;
+DROP TABLE t3;
+connection node_2;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+UPDATE t1 SET f2 = 1 WHERE id=2;
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+DROP TABLE t2, t1;

--- a/mysql-test/suite/galera/r/mwb-1789-drop.result
+++ b/mysql-test/suite/galera/r/mwb-1789-drop.result
@@ -1,0 +1,32 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET GLOBAL wsrep_slave_threads=2;
+CREATE TABLE t1 (
+id INTEGER PRIMARY KEY,
+f2 INTEGER);
+CREATE TABLE t2 (
+f1 INT PRIMARY KEY,
+t1_id INT NOT NULL,
+f2 INTEGER NOT NULL,
+KEY key_t1_id(t1_id),
+CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE);
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+connection node_1;
+DROP TABLE t2;
+connection node_2;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+UPDATE t1 SET f2 = 1 WHERE id=2;
+connection node_2;
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/mwb-1789-alter.test
+++ b/mysql-test/suite/galera/t/mwb-1789-alter.test
@@ -1,0 +1,94 @@
+#
+# BF-BF conflict on MDL locks between:
+#   ALTER TABLE t3 (whose parent table are t3 -> t2 -> t1), and
+#   UPDATE on t1 with t2 referencing t1, and t3 referencing t2.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+#
+# Setup
+#
+--connection node_2
+SET GLOBAL wsrep_slave_threads=2;
+
+CREATE TABLE t1 (
+  id INTEGER PRIMARY KEY,
+  f2 INTEGER
+);
+
+CREATE TABLE t2 (
+  id INT PRIMARY KEY,
+  t1_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t1_id(t1_id),
+  CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE t3 (
+  id INT PRIMARY KEY,
+  t2_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t2_id(t2_id)
+);
+
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+
+#
+# ALTER TABLE t3 and wait for it to reach node_2
+#
+--connection node_2
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+
+--connection node_1
+ALTER TABLE t3 ADD CONSTRAINT key_t2_id FOREIGN KEY (t2_id)
+  REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--connection node_2
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+
+SET SESSION wsrep_sync_wait = 0;
+--let $expected_apply_waits = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
+
+#
+# Issue a UPDATE to table that references t1
+# Notice that we update field f2, not the primary key,
+# and not foreign key. Bug does not manifest if we update
+# one of those fields (because FK keys appended in those cases).
+#
+--connection node_1
+UPDATE t1 SET f2 = 1 WHERE id=2;
+
+
+#
+# Expect the UPDATE to depend on the ALTER TABLE,
+# therefore it should wait for the CREAT TABLE to
+# finish before it can be applied.
+# If bug is present, expect the wait condition
+# to timeout and when the UPDATE applies, it
+# will be granted a MDL lock of type SHARED_READ
+# for table t1. When resumed, the ALTER TABLE will
+# also try to MDL lock t1, causing a BF-BF conflict
+# on that MDL lock.
+#
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_apply_waits FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits';
+--source include/wait_condition.inc
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+
+
+#
+# Cleanup
+#
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+
+DROP TABLE t3, t2, t1;

--- a/mysql-test/suite/galera/t/mwb-1789-create.test
+++ b/mysql-test/suite/galera/t/mwb-1789-create.test
@@ -1,0 +1,93 @@
+#
+# BF-BF conflict on MDL locks between:
+#   CREATE TABLE t3 (whose parent table are t3 -> t2 -> t1), and
+#   UPDATE on t1 with t2 referencing t1, and t3 referencing t2.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+#
+# Setup
+#
+--connection node_2
+SET GLOBAL wsrep_slave_threads=2;
+
+CREATE TABLE t1 (
+  id INTEGER PRIMARY KEY,
+  f2 INTEGER
+);
+
+CREATE TABLE t2 (
+  id INT PRIMARY KEY,
+  t1_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t1_id(t1_id),
+  CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+
+#
+# CREATE TABLE t3 and wait for it to reach node_2
+#
+--connection node_2
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+
+--connection node_1
+CREATE TABLE t3 (
+  id INT PRIMARY KEY,
+  t2_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t2_id(t2_id),
+  CONSTRAINT key_t2_id FOREIGN KEY (t2_id) REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+--connection node_2
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+
+SET SESSION wsrep_sync_wait = 0;
+--let $expected_apply_waits = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
+
+#
+# Issue a UPDATE to table that references t1
+# Notice that we update field f2, not the primary key,
+# and not foreign key. Bug does not manifest if we update
+# one of those fields (because FK keys appended in those cases).
+#
+--connection node_1
+UPDATE t1 SET f2 = 1 WHERE id=2;
+
+
+#
+# Expect the UPDATE to depend on the CREATE TABLE,
+# therefore it should wait for the CREAT TABLE to
+# finish before it can be applied.
+# If bug is present, expect the wait condition
+# to timeout and when the UPDATE applies, it
+# will be granted a MDL lock of type SHARED_READ
+# for table t1. When resumed, the CREATE TABLE will
+# also try to MDL lock t1, causing a BF-BF conflict
+# on that MDL lock.
+#
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_apply_waits FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits';
+--source include/wait_condition.inc
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+
+
+#
+# Cleanup
+#
+SET GLOBAL DEBUG_DBUG="RESET";
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+
+DROP TABLE t3, t2, t1;

--- a/mysql-test/suite/galera/t/mwb-1789-drop-fk2.test
+++ b/mysql-test/suite/galera/t/mwb-1789-drop-fk2.test
@@ -1,0 +1,99 @@
+#
+# BF-BF conflict on MDL locks between: DROP TABLE t2 and UPDATE on t1
+# with t2 referencing t1
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+#
+# Setup
+#
+--connection node_2
+SET GLOBAL wsrep_slave_threads=2;
+
+CREATE TABLE t1 (
+  id INTEGER PRIMARY KEY,
+  f2 INTEGER
+);
+
+CREATE TABLE t2 (
+  id INT PRIMARY KEY,
+  t1_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t1_id(t1_id),
+  CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE t3 (
+  id INT PRIMARY KEY,
+  t2_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t2_id(t2_id),
+  CONSTRAINT key_t2_id FOREIGN KEY (t2_id) REFERENCES t2 (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+
+INSERT INTO t3 VALUES (1,1,1234);
+INSERT INTO t3 VALUES (2,2,1234);
+
+#
+# DROP TABLE t2 and wait for it to reach node_2
+#
+--connection node_2
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+
+--connection node_1
+DROP TABLE t3;
+
+--connection node_2
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+
+SET SESSION wsrep_sync_wait = 0;
+--let $expected_apply_waits = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
+
+#
+# Issue a UPDATE to table that references t1
+# Notice that we update field f2, not the primary key,
+# and not foreign key. Bug does not manifest if we update
+# one of those fields (because FK keys appended in those cases).
+#
+--connection node_1
+UPDATE t1 SET f2 = 1 WHERE id=2;
+
+
+#
+# Expect the UPDATE to depend on the DROP,
+# therefore it should wait for the DROP to
+# finish before it can be applied.
+# If bug is present, expect the wait condition
+# to timeout and when the UPDATE applies, it
+# will be granted a MDL lock of type SHARED_READ
+# for table t1. When resumed, the DROP TABLE will
+# also try to MDL lock t1, causing a BF-BF conflict
+# on that MDL lock.
+#
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_apply_waits FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits';
+--source include/wait_condition.inc
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+
+
+#
+# Cleanup
+#
+SET GLOBAL DEBUG_DBUG="RESET";
+# SET DEBUG_SYNC = 'RESET';
+
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+
+DROP TABLE t2, t1;

--- a/mysql-test/suite/galera/t/mwb-1789-drop.test
+++ b/mysql-test/suite/galera/t/mwb-1789-drop.test
@@ -1,0 +1,85 @@
+#
+# BF-BF conflict on MDL locks between: DROP TABLE t2 and UPDATE on t1
+# with t2 referencing t1
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+#
+# Setup
+#
+--connection node_2
+SET GLOBAL wsrep_slave_threads=2;
+
+CREATE TABLE t1 (
+  id INTEGER PRIMARY KEY,
+  f2 INTEGER);
+
+CREATE TABLE t2 (
+  f1 INT PRIMARY KEY,
+  t1_id INT NOT NULL,
+  f2 INTEGER NOT NULL,
+  KEY key_t1_id(t1_id),
+  CONSTRAINT key_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id) ON UPDATE CASCADE ON DELETE CASCADE);
+
+INSERT INTO t1 VALUES (1,0);
+INSERT INTO t1 VALUES (2,0);
+
+INSERT INTO t2 VALUES (1,1,1234);
+INSERT INTO t2 VALUES (2,2,1234);
+
+#
+# DROP TABLE t2 and wait for it to reach node_2
+#
+--connection node_2
+SET GLOBAL DEBUG_DBUG = '+d,sync.wsrep_apply_toi';
+
+--connection node_1
+DROP TABLE t2;
+
+--connection node_2
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_reached";
+
+SET SESSION wsrep_sync_wait = 0;
+--let $expected_apply_waits = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits'`
+
+#
+# Issue a UPDATE to table that references t1
+# Notice that we update field f2, not the primary key,
+# and not foreign key. Bug does not manifest if we update
+# one of those fields (because FK keys appended in those cases).
+#
+--connection node_1
+UPDATE t1 SET f2 = 1 WHERE id=2;
+
+
+#
+# Expect the UPDATE to depend on the DROP,
+# therefore it should wait for the DROP to
+# finish before it can be applied.
+# If bug is present, expect the wait condition
+# to timeout and when the UPDATE applies, it
+# will be granted a MDL lock of type SHARED_READ
+# for table t1. When resumed, the DROP TABLE will
+# also try to MDL lock t1, causing a BF-BF conflict
+# on that MDL lock.
+#
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_apply_waits FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_apply_waits';
+--source include/wait_condition.inc
+SET GLOBAL DEBUG_DBUG = '-d,sync.wsrep_apply_toi';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi";
+
+
+#
+# Cleanup
+#
+SET GLOBAL DEBUG_DBUG="RESET";
+# SET DEBUG_SYNC = 'RESET';
+
+SET GLOBAL wsrep_slave_threads=DEFAULT;
+
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5049,10 +5049,10 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
       for (TABLE_LIST *table= all_tables; table; table= table->next_global)
       {
         if (!lex->tmp_table() &&
-           (!thd->is_current_stmt_binlog_format_row() ||
-	    !is_temporary_table(table)))
+            (!thd->is_current_stmt_binlog_format_row() ||
+             !is_temporary_table(table)))
         {
-          WSREP_TO_ISOLATION_BEGIN(NULL, NULL, all_tables);
+          WSREP_TO_ISOLATION_BEGIN_DROP(NULL, NULL, all_tables);
           break;
         }
       }

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -241,6 +241,12 @@ void WSREP_LOG(void (*fun)(const char* fmt, ...), const char* fmt, ...);
   if (WSREP_ON && WSREP(thd) && wsrep_to_isolation_begin(thd, db_, table_, table_list_)) \
     goto wsrep_error_label;
 
+#define WSREP_TO_ISOLATION_BEGIN_DROP(db_, table_, table_list_)	\
+  if (WSREP_ON && WSREP(thd) &&                                         \
+      wsrep_to_isolation_begin(thd, db_, table_,                        \
+                               table_list_, nullptr, nullptr, nullptr, true))\
+    goto wsrep_error_label;
+
 #define WSREP_TO_ISOLATION_BEGIN_CREATE(db_, table_, table_list_, create_info_)	\
   if (WSREP_ON && WSREP(thd) &&                                         \
       wsrep_to_isolation_begin(thd, db_, table_,                        \
@@ -353,7 +359,8 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const TABLE_LIST* table_list,
                              const Alter_info* alter_info= nullptr,
                              const wsrep::key_array *fk_tables= nullptr,
-                             const HA_CREATE_INFO* create_info= nullptr);
+                             const HA_CREATE_INFO* create_info= nullptr,
+                             bool is_drop_table_enable= false);
 
 bool wsrep_should_replicate_ddl(THD* thd, const handlerton *db_type);
 bool wsrep_should_replicate_ddl_iterate(THD* thd, const TABLE_LIST* table_list);


### PR DESCRIPTION
Issue:
------
During DROP TABLE execution, if parent tables are opened and MDL locks for those tables are acquired, then concurrent operations to those table could end up in MDL conflict.

For CREATE and ALTER TABLE foreign keys of immediate parent table are getting appended in certiification, but if parent table also has foreign key and if those refrenced tables are opened and MDL locks for those tables are acquired, then concurrent operations to those tables could also end up in MDL conflict.

Solution:
---------
To avoid MDL BF-BF conflicts, append certification keys for all parent's tables so that potentially conflicting operation are not applied in parallel with CREATE, DROP, ALTER TABLE command.