### PR TITLE
MDEV-35659 Suppress error "Transaction was aborted due to Deadlocks"

### DIFF
--- a/mysql-test/suite/galera/t/MDEV-20616.test
+++ b/mysql-test/suite/galera/t/MDEV-20616.test
@@ -242,3 +242,8 @@ CALL proc_update_2;
 DROP PROCEDURE proc_update_1;
 DROP PROCEDURE proc_update_2;
 DROP TABLE t1;
+
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera/t/galera_FK_duplicate_client_insert.test
+++ b/mysql-test/suite/galera/t/galera_FK_duplicate_client_insert.test
@@ -159,3 +159,8 @@ while($counter > 0)
 --connection node_1
 
 drop table user_session,user;
+
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera/t/galera_sequences.test
+++ b/mysql-test/suite/galera/t/galera_sequences.test
@@ -356,3 +356,12 @@ ALTER SEQUENCE IF EXISTS t MINVALUE=1;
 
 DROP TABLE t;
 --echo End of 10.5 tests
+
+
+--disable_query_log
+--connection node_1
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+
+--connection node_2
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera_sr/t/GCF-1018B.test
+++ b/mysql-test/suite/galera_sr/t/GCF-1018B.test
@@ -38,3 +38,7 @@ while ($count)
 --enable_query_log
 
 DROP TABLE t1;
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
@@ -111,3 +111,7 @@ SELECT * FROM t1;
 --connection node_1
 SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log


### PR DESCRIPTION
With MDEV-24035, a new error is logged in the error log when innodb detects a deadlock. This commit adds suppressions to the affected tests in galera test suites.