### PR TITLE
MDEV-35660 Assertion `trx->xid.is_null()' failed

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3076,7 +3076,10 @@ static int innobase_rollback_by_xid(handlerton*, XID *xid) noexcept
     return XAER_RMFAIL;
   if (trx_t *trx= trx_get_trx_by_xid(xid))
   {
-    ut_ad(trx->xid.is_null()); /* should have been cleared by the lookup */
+    /* Lookup by xid clears the transaction xid.
+       For wsrep we clear it below. */
+    ut_ad(trx->xid.is_null() || wsrep_is_wsrep_xid(&trx->xid));
+    trx->xid.null();
     trx_deregister_from_2pc(trx);
     THD* thd= trx->mysql_thd;
     dberr_t err= trx_rollback_for_mysql(trx);


### PR DESCRIPTION
The assertion fails during wsrep recovery step, in function innobase_rollback_by_xid(). The transaction's xid is normally cleared as part of lookup by xid, unless the transaction has a wsrep specific xid.
This is a regression from MDEV-24035 (commit ddd7d5d8e34c3edd) which removed the part clears xid before rollback for transaction with a wsrep specific xid.