### PR TITLE
MDEV-34218: Mariadb Galera cluster fails when replicating from Mysql 5.7 on use of DDL

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2159,11 +2159,18 @@ int wsrep_to_buf_helper(
       domain_id= wsrep_gtid_server.domain_id;
       server_id= wsrep_gtid_server.server_id;
     }
-    Gtid_log_event gtid_event(thd, seqno, domain_id, true,
-                              LOG_EVENT_SUPPRESS_USE_F, true, 0);
-    gtid_event.server_id= server_id;
-    if (!gtid_event.is_valid()) ret= 0;
-    ret= writer.write(&gtid_event);
+    /*
+    * Ignore if both thd->variables.gtid_seq_no and
+    * thd->variables.wsrep_gtid_seq_no are not set.
+    */
+    if (seqno)
+    {
+      Gtid_log_event gtid_event(thd, seqno, domain_id, true,
+                                LOG_EVENT_SUPPRESS_USE_F, true, 0);
+      gtid_event.server_id= server_id;
+      if (!gtid_event.is_valid()) ret= 0;
+      ret= writer.write(&gtid_event);
+    }
   }
   /*
     It's local DDL so in case of possible gtid seqno (SET gtid_seq_no=X)


### PR DESCRIPTION
MDEV-34218: Mariadb Galera cluster fails when replicating from Mysql 5.7 on use of DDL

Issue:
Mariadb Galera cluster fails to replicate from Mysql 5.7 when configured with MASTER_USE_GTID=no option for CHANGE MASTER.

HOST: mysql, mysql 5.7.44 binlog_format=ROW
HOST: m1, mariadb 10.6 GALERA NODE replicating from HOST mysql, Using_Gtid: No (log file and position)
HOST: m2 mariadb 10.6 GALERA NODE
HOST: m3 mariadb 10.6 GALERA NODE

Error on m1:
2024-05-22 16:11:07 1 [ERROR] WSREP: Vote 0 (success) on 78cebda7-1876-11ef-896b-8a58fca50d36:2565 is inconsistent with group. Leaving cluster.

Error on m2 and m3:
2024-05-22 16:11:06 2 [ERROR] Error in Log_event::read_log_event(): 'Found invalid event in binary log', data_len: 42, event_type: -94 2024-05-22 16:11:06 2 [ERROR] WSREP: applier could not read binlog event, seqno: 2565, len: 482

It fails in Gtid_log_event::is_valid() check on secondary node when sequence number sent from primary is 0. On primary for applier or slave thread sequence number is set to 0, when both thd->variables.gtid_seq_no and thd->variables.wsrep_gtid_seq_no have value 0.

Solution:
Skip adding Gtid Event on primary for applier or slave thread when both thd->variables.gtid_seq_no and thd->variables.wsrep_gtid_seq_no have value 0.