### PR TITLE
MDEV-35748 : Attempting to create a CONNECT engine Table results in n…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-35748.result
+++ b/mysql-test/suite/galera/r/MDEV-35748.result
@@ -1,0 +1,31 @@
+connection node_2;
+connection node_1;
+connection node_1;
+INSTALL PLUGIN IF NOT EXISTS connect SONAME 'ha_connect';
+CREATE TABLE t1 (f INT) ENGINE=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+CREATE TABLE t2 (f INT) ENGINE=ROCKSDB;
+CREATE TABLE t3 (f INT) ENGINE=SEQUENCE;
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
+show warnings;
+Level	Code	Message
+Error	1235	This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
+Note	1235	ENGINE=SEQUENCE not supported by Galera
+connection node_2;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f` int(11) DEFAULT NULL
+) ENGINE=CONNECT DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `f` int(11) DEFAULT NULL
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+show create table t3;
+ERROR 42S02: Table 'test.t3' doesn't exist
+connection node_1;
+DROP TABLE t1, t2;
+UNINSTALL PLUGIN IF EXISTS connect;

--- a/mysql-test/suite/galera/t/MDEV-35748.test
+++ b/mysql-test/suite/galera/t/MDEV-35748.test
@@ -1,0 +1,23 @@
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+--source include/have_rocksdb.inc
+
+--connection node_1
+INSTALL PLUGIN IF NOT EXISTS connect SONAME 'ha_connect';
+
+CREATE TABLE t1 (f INT) ENGINE=CONNECT;
+CREATE TABLE t2 (f INT) ENGINE=ROCKSDB;
+--error ER_NOT_SUPPORTED_YET
+CREATE TABLE t3 (f INT) ENGINE=SEQUENCE;
+show warnings;
+
+--connection node_2
+show create table t1;
+show create table t2;
+--error ER_NO_SUCH_TABLE
+show create table t3;
+
+--connection node_1
+DROP TABLE t1, t2;
+UNINSTALL PLUGIN IF EXISTS connect;
+

--- a/sql/sql_cmd.h
+++ b/sql/sql_cmd.h
@@ -141,6 +141,8 @@ public:
                                          handlerton **ha,
                                          bool tmp_table);
   bool is_set() { return m_storage_engine_name.str != NULL; }
+
+  const LEX_CSTRING *name() const { return &m_storage_engine_name; }
 };
 
 


### PR DESCRIPTION
…on-InnoDB sequences in Galera cluster error

Problem was incorrect condition on wsrep_check_sequence when ENGINE!=InnoDB.

Fix is not use DB_TYPE_XXX because it is not correct on dynamic storage engines. Instead used storage engine name is looked from thd->lex->m_sql_cmd->option_storage_engine_name.

For CREATE TABLE allow anyting except ENGINE=SEQUENCE. For CREATE SEQUENCE only ENGINE=InnoDB is supported. For ALTER TABLE if original table contains sequence information only ENGINE=InnoDB is supported.