### PR TITLE
MDEV-35852 : ASAN heap-use-after-free in WSREP_DEBUG after INSERT DEL…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-35852.result
+++ b/mysql-test/suite/galera/r/MDEV-35852.result
@@ -1,0 +1,8 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t (a INT) ENGINE=InnoDB;
+INSERT DELAYED INTO t VALUES ();
+ERROR HY000: DELAYED option not supported for table 't'
+DROP TABLE t;
+INSERT DELAYED t1 () VALUES ();
+ERROR 42S02: Table 'test.t1' doesn't exist

--- a/mysql-test/suite/galera/t/MDEV-35852.cnf
+++ b/mysql-test/suite/galera/t/MDEV-35852.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep-debug=1

--- a/mysql-test/suite/galera/t/MDEV-35852.test
+++ b/mysql-test/suite/galera/t/MDEV-35852.test
@@ -1,0 +1,9 @@
+--source include/galera_cluster.inc
+
+CREATE TABLE t (a INT) ENGINE=InnoDB;
+--error ER_DELAYED_NOT_SUPPORTED
+INSERT DELAYED INTO t VALUES ();
+DROP TABLE t;
+
+--error ER_NO_SUCH_TABLE
+INSERT DELAYED t1 () VALUES ();

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -86,7 +86,14 @@ extern "C" const char *wsrep_thd_query(const THD *thd)
         return "SET PASSWORD";
       /* fallthrough */
     default:
+    {
+      // Note that DELAYED thread might delete thd->query() when
+      // it is destroyed, but trans_rollback is called after it
+      if (thd->system_thread == SYSTEM_THREAD_DELAYED_INSERT &&
+	  thd->killed == KILL_QUERY_HARD)
+	return "NULL";
       return (thd->query() ? thd->query() : "NULL");
+    }
   }
   return "NULL";
 }


### PR DESCRIPTION
…AYED

Problem was that in case of INSERT DELAYED thd->query() is deleted before we call trans_rollback where WSREP_DEBUG could access thd->query().

Fix is to return NULL from wsrep_query() in case when thd is killed and thread is insert delayed thread.