### PR TITLE
MDEV-35941 : galera_bf_abort_lock_table fails with wait for metadata …

### DIFF
--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.cnf
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.cnf
@@ -1,5 +1,0 @@
-!include ../galera_2nodes.cnf
-
-[mysqld.1]
-wsrep-debug=1
-loose-galera-bf-abort-lock-table=1

--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
@@ -1,6 +1,5 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
---source include/force_restart.inc
 
 #
 # Test that a local LOCK TABLE will NOT be broken by an incoming remote transaction against that table
@@ -20,13 +19,13 @@ INSERT INTO t1 VALUES (2);
 SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
---source include/wait_condition_with_debug_and_kill.inc
+--source include/wait_condition_with_debug.inc
 
 UNLOCK TABLES;
 
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
---source include/wait_condition_with_debug_and_kill.inc
+--source include/wait_condition_with_debug.inc
 
 COMMIT;
 SELECT COUNT(*) = 1 FROM t1;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -3191,11 +3191,9 @@ void wsrep_to_isolation_end(THD *thd)
 
   @param  requestor_ctx        The MDL context of the requestor
   @param  ticket               MDL ticket for the requested lock
+  @param  key                  The key of the object (data) being protected
 
-  @retval TRUE   Lock request can be granted
-  @retval FALSE  Lock request cannot be granted
 */
-
 void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
                                const MDL_ticket *ticket,
                                const MDL_key *key)
@@ -3268,13 +3266,20 @@ void wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,
             (granted_thd->system_thread != NON_SYSTEM_THREAD &&
              granted_thd->mdl_context.has_explicit_locks()))
     {
-      WSREP_DEBUG("BF thread waiting for FLUSH");
+      WSREP_DEBUG("BF thread waiting for %s",
+		  granted_thd->lex->sql_command == SQLCOM_FLUSH ? "FLUSH" : "BACKUP");
       ticket->wsrep_report(wsrep_debug);
+
       if (granted_thd->current_backup_stage != BACKUP_FINISHED &&
 	  wsrep_check_mode(WSREP_MODE_BF_MARIABACKUP))
       {
 	wsrep_abort_thd(request_thd, granted_thd, 1);
       }
+    }
+    else if (granted_thd->lex->sql_command == SQLCOM_LOCK_TABLES)
+    {
+      WSREP_DEBUG("BF thread waiting for LOCK TABLES");
+      ticket->wsrep_report(wsrep_debug);
     }
     else if (request_thd->lex->sql_command == SQLCOM_DROP_TABLE)
     {


### PR DESCRIPTION
…lock

Problem was missing case from wsrep_handle_mdl_conflict. Test case was trying to confirm that LOCK TABLE thread is not BF-aborted. However as case was missing it was BF-aborted. Test case passed because BF-aborting takes time and used wait condition might see expected thread status before it was BF-aborted. Test naturally failed if BF-aborting was done early enough.

Fix is to add missing case for SQLCOM_LOCK_TABLES to wsrep_handle_mdl_conflict.

Note that using LOCK TABLE is still not recomended on cluster because it could cause cluster hang.