### PR TITLE
MDEV-36509 : Galera test failure on galera_sr.mysql-wsrep-features#165

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -7108,10 +7108,6 @@ and less modified rows. Bit 0 is used to prefer orig_trx in case of a tie.
       victim->lock.was_chosen_as_deadlock_victim= true;
       DEBUG_SYNC_C("deadlock_report_before_lock_releasing");
       lock_cancel_waiting_and_release<true>(victim->lock.wait_lock);
-#ifdef WITH_WSREP
-      if (victim->is_wsrep() && wsrep_thd_is_SR(victim->mysql_thd))
-        wsrep_handle_SR_rollback(trx->mysql_thd, victim->mysql_thd);
-#endif
     }
 
 func_exit:


### PR DESCRIPTION
Problem was that thread was holding lock_sys.wait_mutex when streaming replication transaction rollback was handled and in wsrep-lib requests THD::LOCK_thd_kill mutex causing wrong mutex usage (thd->reset_globals()).

Fix is to release lock_sys.wait_mutex before we enter wsrep-lib from Deadlock::report() and acquire it back when complated. This is already expected as commented on Deadlock::check_and_resolve(). wsrep-lib internals should not be executed while holding lock_sys.wait_mutex because it does not access lock_sys internals and aborting transaction might take time. wsrep-lib should take THD::LOCK_thd_kill to avoid victim THD to be released.