### PR TITLE
MDEV-36710: Revert "MDEV-33136: backport corrections from 10.11+"

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-33136.result
+++ b/mysql-test/suite/galera/r/MDEV-33136.result
@@ -4,7 +4,7 @@ connect node_1a,127.0.0.1,root,,test,$NODE_MYPORT_1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 connection node_1a;
-RENAME TABLE t1 TO tmp, tmp TO t1;
+TRUNCATE TABLE t1;
 SET SESSION wsrep_retry_autocommit = 0;
 SET DEBUG_SYNC = 'dict_stats_mdl_acquired SIGNAL may_toi WAIT_FOR bf_abort';
 INSERT INTO t1 VALUES (1);

--- a/mysql-test/suite/galera/t/MDEV-33136.test
+++ b/mysql-test/suite/galera/t/MDEV-33136.test
@@ -20,8 +20,8 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 --connection node_1a
-RENAME TABLE t1 TO tmp, tmp TO t1;
-# RENAME forces the next statement to re-read statistics from persistent storage,
+TRUNCATE TABLE t1;
+# TRUNCATE forces the next statement to re-read statistics from persistent storage,
 # which will acquire MDL locks on the statistics tables in InnoDB.
 SET SESSION wsrep_retry_autocommit = 0;
 SET DEBUG_SYNC = 'dict_stats_mdl_acquired SIGNAL may_toi WAIT_FOR bf_abort';


### PR DESCRIPTION
This reverts commit 0403f0147f176190b6a2ca61996c12eada275e4c. It caused MDEV-33136 test to fail in 10.6 branch.