### PR TITLE
MDEV-36711 Galera Cluster node reports wrong error code in detached state

### DIFF
--- a/sql/table.cc
+++ b/sql/table.cc
@@ -303,6 +303,20 @@ TABLE_CATEGORY get_table_category(const Lex_ident_db &db,
   if (is_perfschema_db(&db))
     return TABLE_CATEGORY_PERFORMANCE;
 
+#ifdef WITH_WSREP
+  if (db.streq(WSREP_LEX_SCHEMA))
+  {
+    if(name.streq(WSREP_LEX_STREAMING))
+      return TABLE_CATEGORY_INFORMATION;
+    if (name.streq(WSREP_LEX_CLUSTER))
+      return TABLE_CATEGORY_INFORMATION;
+    if (name.streq(WSREP_LEX_MEMBERS))
+      return TABLE_CATEGORY_INFORMATION;
+    if (name.streq(WSREP_LEX_ALLOWLIST))
+      return TABLE_CATEGORY_INFORMATION;
+  }
+#endif /* WITH_WSREP */
+
   if (db.streq(MYSQL_SCHEMA_NAME))
   {
     if (is_system_table_name(name))
@@ -318,20 +332,6 @@ TABLE_CATEGORY get_table_category(const Lex_ident_db &db,
 
     return TABLE_CATEGORY_MYSQL;
   }
-
-#ifdef WITH_WSREP
-  if (db.streq(WSREP_LEX_SCHEMA))
-  {
-    if(name.streq(WSREP_LEX_STREAMING))
-      return TABLE_CATEGORY_INFORMATION;
-    if (name.streq(WSREP_LEX_CLUSTER))
-      return TABLE_CATEGORY_INFORMATION;
-    if (name.streq(WSREP_LEX_MEMBERS))
-      return TABLE_CATEGORY_INFORMATION;
-    if (name.streq(WSREP_LEX_ALLOWLIST))
-      return TABLE_CATEGORY_INFORMATION;
-  }
-#endif /* WITH_WSREP */
 
   return TABLE_CATEGORY_USER;
 }


### PR DESCRIPTION
Bug fix for a Galera Cluster bug: When a Galera Cluster node is detached from the cluster it may report wrong error code for an executed query. This caused the MTR test galera.MDEV-35946 for MDEV-35946.

The problem occurs because the gategory of the table mysql.wsrep_streaming_log was changed from TABLE_CATEGORY_MYSQL to TABLE_CATEGORY_INFORMATION by the fix for [MDEV-33881](https://jira.mariadb.org/browse/MDEV-33881) Userstat skips system tables inconsistently. This is a new issue unrelated to the problem described by [MDEV-35946](https://jira.mariadb.org/browse/MDEV-35946).