### PR TITLE
MDEV-36134 : Mariadb server crashed during insert

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_with_filtering.result
@@ -1,0 +1,137 @@
+connection node_2;
+connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_2;
+START SLAVE;
+connection node_3;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+connection node_2;
+connection node_1;
+#
+# Set up replication filtering this should work for slave
+#
+connection node_2;
+STOP SLAVE;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+@@replicate_ignore_table
+mysql.gtid_slave_pos,test.t2
+START SLAVE;
+#
+# Set up replication filtering, this should not have any effect
+#
+connection node_1;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+@@replicate_ignore_table
+mysql.gtid_slave_pos,test.t2
+#
+# Insert data to MariaDB master, inserts to t2 should not be on slave
+#
+connection node_3;
+INSERT INTO t1 SELECT * FROM seq_1_to_100;
+INSERT INTO t2 SELECT * FROM seq_1_to_100;
+INSERT INTO t3 SELECT * FROM seq_1_to_100;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+100
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+100
+SELECT COUNT(*) FROM t3;
+COUNT(*)
+100
+connection node_2;
+SELECT COUNT(*) AS EXPECT_100 FROM t1;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_100 FROM t3;
+EXPECT_100
+100
+#
+# Insert data to Galera node_2, all these should be replicated
+#
+INSERT INTO t1 SELECT * FROM seq_101_to_200;
+INSERT INTO t2 SELECT * FROM seq_101_to_200;
+INSERT INTO t3 SELECT * FROM seq_101_to_200;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+EXPECT_200
+200
+connection node_1;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+EXPECT_100
+100
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+EXPECT_200
+200
+#
+# Insert data to Galera node_1, all these should be replicated
+#
+INSERT INTO t1 SELECT * FROM seq_201_to_300;
+INSERT INTO t2 SELECT * FROM seq_201_to_300;
+INSERT INTO t3 SELECT * FROM seq_201_to_300;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+connection node_3;
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+
+connection node_1;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+0-3-6
+connection node_2;
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+EXPECT_300
+300
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+EXPECT_200
+200
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+EXPECT_300
+300
+SELECT @@GLOBAL.gtid_slave_pos;
+@@GLOBAL.gtid_slave_pos
+0-3-6
+connection node_2;
+STOP SLAVE;
+RESET SLAVE ALL;
+SET GLOBAL replicate_ignore_table='';
+connection node_1;
+SET GLOBAL replicate_ignore_table='';
+connection node_3;
+DROP TABLE t1,t2,t3;
+connection node_2;
+DROP TABLE t1,t2,t3;
+connection node_3;
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_with_filtering.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_with_filtering.cnf
@@ -1,0 +1,12 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mariadbd.1]
+wsrep-gtid-mode=ON
+log-bin
+log-slave-updates
+
+[mariadbd.2]
+wsrep-gtid-mode=ON
+log-bin
+log-slave-updates
+

--- a/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_with_filtering.test
@@ -1,0 +1,146 @@
+#
+# Test Galera as a slave to a MySQL master
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+# mariadb master (node_3) ----async replication--->galera node_2 <---galera replication-->node_1
+#
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+# As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
+# we open the node_3 connection here
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_2
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_SSL_VERIFY_SERVER_CERT=0, MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE;
+
+--connection node_3
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3';
+--source include/wait_condition.inc
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't3';
+--source include/wait_condition.inc
+
+--echo #
+--echo # Set up replication filtering this should work for slave
+--echo #
+--connection node_2
+STOP SLAVE;
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_SSL_VERIFY_SERVER_CERT=0, MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE;
+
+--echo #
+--echo # Set up replication filtering, this should not have any effect
+--echo #
+--connection node_1
+SET GLOBAL replicate_ignore_table='test.t2,mysql.gtid_slave_pos';
+SELECT @@replicate_ignore_table;
+
+--echo #
+--echo # Insert data to MariaDB master, inserts to t2 should not be on slave
+--echo #
+--connection node_3
+INSERT INTO t1 SELECT * FROM seq_1_to_100;
+INSERT INTO t2 SELECT * FROM seq_1_to_100;
+INSERT INTO t3 SELECT * FROM seq_1_to_100;
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+SELECT COUNT(*) FROM t3;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 100 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 100 FROM t3;
+--source include/wait_condition.inc
+
+SELECT COUNT(*) AS EXPECT_100 FROM t1;
+SELECT COUNT(*) AS EXPECT_0 FROM t2;
+SELECT COUNT(*) AS EXPECT_100 FROM t3;
+
+--echo #
+--echo # Insert data to Galera node_2, all these should be replicated
+--echo #
+INSERT INTO t1 SELECT * FROM seq_101_to_200;
+INSERT INTO t2 SELECT * FROM seq_101_to_200;
+INSERT INTO t3 SELECT * FROM seq_101_to_200;
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 200 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_200 FROM t1;
+SELECT COUNT(*) AS EXPECT_100 FROM t2;
+SELECT COUNT(*) AS EXPECT_200 FROM t3;
+
+--echo #
+--echo # Insert data to Galera node_1, all these should be replicated
+--echo #
+INSERT INTO t1 SELECT * FROM seq_201_to_300;
+INSERT INTO t2 SELECT * FROM seq_201_to_300;
+INSERT INTO t3 SELECT * FROM seq_201_to_300;
+
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+
+--connection node_3
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 300 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 300 FROM t3;
+--source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_300 FROM t1;
+SELECT COUNT(*) AS EXPECT_200 FROM t2;
+SELECT COUNT(*) AS EXPECT_300 FROM t3;
+SELECT @@GLOBAL.gtid_slave_pos;
+
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+SET GLOBAL replicate_ignore_table='';
+
+--connection node_1
+SET GLOBAL replicate_ignore_table='';
+
+--connection node_3
+DROP TABLE t1,t2,t3;
+
+--connection node_2
+DROP TABLE t1,t2,t3;
+
+--connection node_3
+RESET MASTER;

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -6522,8 +6522,8 @@ check_table_map(rpl_group_info *rgi, RPL_TABLE_LIST *table_list)
   DBUG_ENTER("check_table_map");
   enum_tbl_map_status res= OK_TO_PROCESS;
   Relay_log_info *rli= rgi->rli;
-  if ((rgi->thd->slave_thread /* filtering is for slave only */ ||
-        IF_WSREP((WSREP(rgi->thd) && rgi->thd->wsrep_applier), 0)) &&
+
+  if (rgi->thd->slave_thread /* filtering is for slave only */ &&
       (!rli->mi->rpl_filter->db_ok(table_list->db.str) ||
        (rli->mi->rpl_filter->is_on() && !rli->mi->rpl_filter->tables_ok("", table_list))))
     res= FILTERED_OUT;


### PR DESCRIPTION
Replication filtering is not safe for cluster consistency. There is problem when two or more filtering rules are provided by user. Here, we disable replication filtering inside a Galera cluster for now. To support safe replication filereing in the Galera cluster it should also effect SST/IST.