### PR TITLE
MDEV-34761 : Assertion `client_state_.mode() == wsrep::client_state::…

### DIFF
--- a/mysql-test/suite/galera/r/enforce_storage_engine2.result
+++ b/mysql-test/suite/galera/r/enforce_storage_engine2.result
@@ -7,23 +7,15 @@ connection node_1;
 connection node_1;
 CREATE TABLE t1(i INT) ENGINE=INNODB;
 CREATE TABLE t2(i INT) ENGINE=MYISAM;
-Warnings:
-Note	1266	Using storage engine InnoDB for table 't2'
-Note	1266	Using storage engine InnoDB for table 't2'
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
 connection node_2;
 SHOW TABLES;
 Tables_in_test
 t1
-t2
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
   `i` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-SHOW CREATE TABLE t2;
-Table	Create Table
-t2	CREATE TABLE `t2` (
-  `i` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-DROP TABLE t1, t2;
+DROP TABLE t1;
 # End of tests

--- a/mysql-test/suite/galera/r/galera_aria.result
+++ b/mysql-test/suite/galera/r/galera_aria.result
@@ -1,0 +1,25 @@
+connection node_2;
+connection node_1;
+set session sql_mode='';
+SET @@enforce_storage_engine=INNODB;
+CREATE TABLE t1 (c INT ) ENGINE=ARIA;
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+SHOW WARNINGS;
+Level	Code	Message
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+CREATE TABLE t1 (c INT );
+DROP TABLE t1;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+DROP TABLE t1;
+SET @@enforce_storage_engine=ARIA;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+ERROR HY000: The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+SHOW WARNINGS;
+Level	Code	Message
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set
+Error	1290	The MariaDB server is running with the ENFORCE_STORAGE_ENGINE option so it cannot execute this statement
+Note	1290	Do not use ENGINE=x when @@enforce_storage_engine is set

--- a/mysql-test/suite/galera/t/enforce_storage_engine2.test
+++ b/mysql-test/suite/galera/t/enforce_storage_engine2.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_aria.inc
 
 --echo #
 --echo # MDEV-9312: storage engine not enforced during galera cluster
@@ -7,14 +8,21 @@
 --echo #
 --connection node_1
 CREATE TABLE t1(i INT) ENGINE=INNODB;
+#
+# This is not anymore supported because enforce_storage_engine
+# is local setting and final used storage engine
+# on other members of cluster depend on their configuration.
+# Currently, there is no way to query remote node
+# configuration.
+#
+--error ER_OPTION_PREVENTS_STATEMENT 
 CREATE TABLE t2(i INT) ENGINE=MYISAM;
 
 --connection node_2
 SHOW TABLES;
 SHOW CREATE TABLE t1;
-SHOW CREATE TABLE t2;
 
 # Cleanup
-DROP TABLE t1, t2;
+DROP TABLE t1;
 
 --echo # End of tests

--- a/mysql-test/suite/galera/t/galera_aria.test
+++ b/mysql-test/suite/galera/t/galera_aria.test
@@ -1,0 +1,19 @@
+--source include/galera_cluster.inc
+--source include/have_aria.inc
+--source include/log_bin.inc
+
+set session sql_mode='';
+SET @@enforce_storage_engine=INNODB;
+--error ER_OPTION_PREVENTS_STATEMENT 
+CREATE TABLE t1 (c INT ) ENGINE=ARIA;
+SHOW WARNINGS;
+
+CREATE TABLE t1 (c INT );
+DROP TABLE t1;
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+DROP TABLE t1;
+
+SET @@enforce_storage_engine=ARIA;
+--error ER_OPTION_PREVENTS_STATEMENT 
+CREATE TABLE t1 (c INT ) ENGINE=INNODB;
+SHOW WARNINGS;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -12119,6 +12119,23 @@ bool check_engine(THD *thd, const char *db_name,
       my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "NO_ENGINE_SUBSTITUTION");
       DBUG_RETURN(TRUE);
     }
+#ifdef WITH_WSREP
+    /*  @@enforce_storage_engine is local, if user has used
+	ENGINE=XXX we can't allow it in cluster in this
+	case as enf_engine != new _engine. This is because
+        original stmt is replicated including ENGINE=XXX and
+        here */
+    if ((create_info->used_fields & HA_CREATE_USED_ENGINE) &&
+	WSREP(thd))
+    {
+      my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "ENFORCE_STORAGE_ENGINE");
+      push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+			  ER_OPTION_PREVENTS_STATEMENT,
+			  "Do not use ENGINE=x when @@enforce_storage_engine is set");
+
+      DBUG_RETURN(TRUE);
+    }
+#endif
     *new_engine= enf_engine;
   }
 


### PR DESCRIPTION
…m_local' failed in int wsrep::transaction::after_statement(wsrep::unique_lock<wsrep::mutex>&)

@@enforce_storage_engine is local setting and there is no knowledge how other nodes are configured. Statement CREATE TABLE xxx ENGINE=yyy is replicated as it is and if required engine != enforced engine it could lead inconsistent used storage engine in the cluster.

Fix is to return error and a warning if required engine is not same as enforced engine.