### PR TITLE
MENT-2297: Inconsistency detected - create sequence

### DIFF
--- a/sql/sql_sequence.cc
+++ b/sql/sql_sequence.cc
@@ -133,6 +133,12 @@ bool sequence_definition::check_and_adjust(bool set_reserved_until)
        (real_increment < 0 && reserved_until <= max_value)))
     DBUG_RETURN(FALSE);
 
+  sql_print_error("Check failed, sequence is invalid. "
+                  "max_value: %lld min_value: %lld start: %lld "
+                  "cache: %lld real_increment: %lld max_increment: %lld "
+	          "reserved_until: %lld next_free_value: %lld.",
+                  max_value, min_value, start, cache, real_increment,
+                  max_increment, reserved_until, next_free_value);
   DBUG_RETURN(TRUE);                           // Error
 }
 


### PR DESCRIPTION
Issue:
The Create SEQUENCE object on the first/active galera node:
  CREATE SEQUENCE `seq_moni_num` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 0 cache 1000 nocycle ENGINE=InnoDB

Execute the following query for two or three times on the other nodes:
  SELECT NEXT VALUE FOR seq_moni_num;

Resulted in below error on applier node:
[ERROR] Slave SQL: Could not execute Write_rows_v1 event on table monitor.seq_moni_num; Unknown error, Error_code: 1105; handler error No Error!; the event's master log FIRST, end_log_pos 0, Internal MariaDB error code: 1105 [Warning] WSREP: Event 3 Write_rows_v1 apply failed: 195, seqno 28222

Solution:
The error HA_ERR_SEQUENCE_INVALID_DATA 195 happens in sequence_definition::check_and_adjust() but not enough log are provided to know which limit reached or condition failed. So more logs are added on failure in sequence_definition::check_and_adjust().