### PR TITLE
MDEV-35523 : Server crashes with "WSREP: Unknown writeset version: -1"

### DIFF
--- a/mysql-test/suite/wsrep/r/MDEV-20625.result
+++ b/mysql-test/suite/wsrep/r/MDEV-20625.result
@@ -1,4 +1,5 @@
 SET GLOBAL wsrep_on=ON;
+ERROR HY000: Galera replication not supported
 SHOW GLOBAL STATUS LIKE 'wsrep_cluster_size';
 Variable_name	Value
 wsrep_cluster_size	0

--- a/mysql-test/suite/wsrep/r/wsrep_off.result
+++ b/mysql-test/suite/wsrep/r/wsrep_off.result
@@ -1,0 +1,6 @@
+SET GLOBAL wsrep_on=ON;
+ERROR HY000: Galera replication not supported
+REPAIR TABLE performance_schema.setup_objects;
+Table	Op	Msg_type	Msg_text
+performance_schema.setup_objects	repair	note	The storage engine for the table doesn't support repair
+SET GLOBAL wsrep_on=OFF;

--- a/mysql-test/suite/wsrep/t/wsrep_off.cnf
+++ b/mysql-test/suite/wsrep/t/wsrep_off.cnf
@@ -1,0 +1,17 @@
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld]
+wsrep-on=OFF
+wsrep-provider=@ENV.WSREP_PROVIDER
+log-bin
+binlog-format=row
+loose-wsrep_cluster_address=gcomm://
+loose-wsrep_node_address='127.0.0.1:@mysqld.1.#galera_port'
+loose-wsrep-incoming-address=127.0.0.1:@mysqld.1.port
+
+[mysqld.1]
+wsrep-on=OFF
+#galera_port=@OPT.port
+#ist_port=@OPT.port
+#sst_port=@OPT.port

--- a/mysql-test/suite/wsrep/t/wsrep_off.test
+++ b/mysql-test/suite/wsrep/t/wsrep_off.test
@@ -1,11 +1,8 @@
-#
-# Check SHOW GLOBAL STATUS after dynamic setting WSREP=ON
-#
 --source include/have_innodb.inc
 --source include/have_wsrep_provider.inc
 --source include/have_binlog_format_row.inc
 
 --error ER_GALERA_REPLICATION_NOT_SUPPORTED
 SET GLOBAL wsrep_on=ON;
-SHOW GLOBAL STATUS LIKE 'wsrep_cluster_size';
+REPAIR TABLE performance_schema.setup_objects;
 SET GLOBAL wsrep_on=OFF;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2780,9 +2780,17 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
   WSREP_DEBUG("TOI Begin: %s", wsrep_thd_query(thd));
   DEBUG_SYNC(thd, "wsrep_before_toi_begin");
 
-  if (wsrep_can_run_in_toi(thd, db, table, table_list, create_info) == false)
+  if (!wsrep_ready ||
+      wsrep_can_run_in_toi(thd, db, table, table_list, create_info) == false)
   {
     WSREP_DEBUG("No TOI for %s", wsrep_thd_query(thd));
+    if (!wsrep_ready)
+    {
+      my_error(ER_GALERA_REPLICATION_NOT_SUPPORTED, MYF(0));
+      push_warning_printf(thd, Sql_state_errno_level::WARN_LEVEL_WARN,
+                          ER_GALERA_REPLICATION_NOT_SUPPORTED,
+                          "Galera cluster is not ready to execute replication");
+    }
     return 1;
   }
 

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include "wsrep_trans_observer.h"
 #include "wsrep_server_state.h"
+#include "wsrep_mysqld.h"
 
 ulong   wsrep_reject_queries;
 
@@ -120,6 +121,14 @@ bool wsrep_on_update (sys_var *self, THD* thd, enum_var_type var_type)
       if (wsrep_init())
       {
         my_error(ER_CANT_OPEN_LIBRARY, MYF(0), tmp, errno, "wsrep_init failed");
+        saved_wsrep_on= false;
+      }
+
+      if (!wsrep_ready_get())
+      {
+        my_error(ER_GALERA_REPLICATION_NOT_SUPPORTED, MYF(0));
+        WSREP_INFO("Failed to start Galera replication. Please check your "
+                   "configuration.");
         saved_wsrep_on= false;
       }
 


### PR DESCRIPTION
Cluster configuration was incorrect e.g. wsrep_node_address was missing. Therefore, Galera replication was not properly initialized and TOI is not supported.

Fix is to check when user tries to start Galera replication with wsrep_on=ON that Galera replication is properly initialized and node is ready to receive operations. If Galera replication is not properly initialized return a error.