### PR TITLE
Bug fix for the MTR test galera.galera_bf_abort_lock_table (MDEV-36598).

### DIFF
--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
@@ -10,7 +10,6 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 --connection node_2
 # Wait for Galera to replicate "CREATE TABLE t1" to node_2
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
---let $wait_condition_on_error_output = SHOW ALL SLAVES STATUS;
 --source include/wait_condition_with_debug.inc
 
 SET AUTOCOMMIT=OFF;


### PR DESCRIPTION
Sometimes the MTR test galera.galera_bf_abort_lock_table failed with a timeout. The root cause for the failure was an error in the logic of the MTR test: it was possible that a table created on node 1 was not replicated to node 2 before an attempt was made to lock it on node 2. This resulted in a timeout later in the test.