### PR TITLE
MDEV-37229: Set proper trx isolation level before every applied event

### DIFF
--- a/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
@@ -33,6 +33,28 @@ i	c
 3	dummy_text
 5	dummy_text
 7	dummy_text
+insert into t1(i) values(null);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+insert into t1(i) values(null);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+insert into t1(i) values(null);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+insert into t1(i) values(null);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
+select * from t1 order by i;
+i	c
+1	dummy_text
+3	dummy_text
+5	dummy_text
+7	dummy_text
+9	dummy_text
+11	dummy_text
+13	dummy_text
+15	dummy_text
 connection node_2;
 show variables like 'auto_increment%';
 Variable_name	Value
@@ -44,6 +66,10 @@ i	c
 3	dummy_text
 5	dummy_text
 7	dummy_text
+9	dummy_text
+11	dummy_text
+13	dummy_text
+15	dummy_text
 SET GLOBAL wsrep_forced_binlog_format='none';
 connection node_1;
 SET GLOBAL wsrep_forced_binlog_format='none';

--- a/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.cnf
+++ b/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.cnf
@@ -5,5 +5,6 @@ auto_increment_offset=1
 auto_increment_increment=1
 
 [mysqld.2]
+wsrep_slave_threads=2
 auto_increment_offset=2
 auto_increment_increment=1

--- a/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
@@ -48,8 +48,17 @@ insert into t1(i) values(null), (null), (null);
 
 select * from t1 order by i;
 
+# Ensure both appliers have some work to perform in parallel.
+# This way we can see they both have proper isolation level set.
+insert into t1(i) values(null);
+insert into t1(i) values(null);
+insert into t1(i) values(null);
+insert into t1(i) values(null);
+
+select * from t1 order by i;
+
 --connection node_2
---let $wait_condition = SELECT COUNT(*) = 4 FROM t1;
+--let $wait_condition = SELECT COUNT(*) = 8 FROM t1;
 --source include/wait_condition.inc
 show variables like 'auto_increment%';
 select * from t1 order by i;

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -203,6 +203,19 @@ int wsrep_apply_events(THD*        thd,
       }
     }
 
+    /* Statement-based replication requires InnoDB repeatable read
+       transaction isolation level or higher. */
+    if (wsrep_forced_binlog_format == BINLOG_FORMAT_STMT)
+    {
+      thd->variables.tx_isolation= ISO_REPEATABLE_READ;
+      thd->tx_isolation          = ISO_REPEATABLE_READ;
+    }
+    else
+    {
+      thd->variables.tx_isolation= ISO_READ_COMMITTED;
+      thd->tx_isolation          = ISO_READ_COMMITTED;
+    }
+
     if (LOG_EVENT_IS_WRITE_ROW(typ) ||
         LOG_EVENT_IS_UPDATE_ROW(typ) ||
         LOG_EVENT_IS_DELETE_ROW(typ))


### PR DESCRIPTION
Apparently, applier thread performing IST would be left with REPEATABLE_READ isolation level.

Every applier thread in Galera should run with READ_COMMITTED transaction isolation level to prevent applying issues caused by InnoDB gap locks.

The exception is statement-based replication, where REPEATABLE_READ is required by the server code.