### PR TITLE
MGL-66 : Test failure on galera.galera_bf_abort_lock_table

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_abort_lock_table.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_lock_table.result
@@ -1,18 +1,31 @@
 connection node_2;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
-connection node_2;
-SET AUTOCOMMIT=OFF;
+INSERT INTO t1 values (1);
 LOCK TABLE t1 WRITE;
-connection node_1;
-INSERT INTO t1 VALUES (2);
-connection node_2;
+connect node_1_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1_ctrl;
 SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC= 'wsrep_before_mdl_wait SIGNAL before_mdl_wait WAIT_FOR mdl_wait_continue';
+INSERT INTO t1 VALUES (2);;
+connection node_1;
+# Wait until INSERT is blocked before MDL lock wait
+SET DEBUG_SYNC= 'now WAIT_FOR before_mdl_wait';
+SELECT COUNT(*) AS EXPECT_1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'debug sync point: wsrep_before_mdl_wait%';
+EXPECT_1
+1
+SET DEBUG_SYNC = 'now SIGNAL mdl_wait_continue';
+connection node_1;
 UNLOCK TABLES;
 COMMIT;
-SELECT COUNT(*) = 1 FROM t1;
-COUNT(*) = 1
-1
+connection node_1_ctrl;
+SELECT COUNT(*) AS EXPECT_2 FROM t1;
+EXPECT_2
+2
+connection node_2;
+SELECT COUNT(*) AS EXPECT_2 FROM t1;
+EXPECT_2
+2
 wsrep_local_aborts_increment
-1
+0
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
@@ -1,39 +1,49 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
 
 #
 # Test that a local LOCK TABLE will NOT be broken by an incoming remote transaction against that table
 #
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
-
---connection node_2
-SET AUTOCOMMIT=OFF;
+INSERT INTO t1 values (1);
 --let $wsrep_local_bf_aborts_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
 LOCK TABLE t1 WRITE;
 
+#
+# Set sync point
+#
+--connect node_1_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1_ctrl
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC= 'wsrep_before_mdl_wait SIGNAL before_mdl_wait WAIT_FOR mdl_wait_continue';
+--send INSERT INTO t1 VALUES (2);
+
 --connection node_1
-INSERT INTO t1 VALUES (2);
+--echo # Wait until INSERT is blocked before MDL lock wait
+SET DEBUG_SYNC= 'now WAIT_FOR before_mdl_wait';
+# INSERT should wait for MDL-lock instead of BF aborting LOCK TABLE
+SELECT COUNT(*) AS EXPECT_1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'debug sync point: wsrep_before_mdl_wait%';
+SET DEBUG_SYNC = 'now SIGNAL mdl_wait_continue';
+
+--connection node_1
+# Release INSERT
+UNLOCK TABLES;
+COMMIT;
+
+--connection node_1_ctrl
+--reap
+SELECT COUNT(*) AS EXPECT_2 FROM t1;
 
 --connection node_2
-SET SESSION wsrep_sync_wait = 0;
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND (STATE LIKE 'Waiting for table metadata lock%' OR STATE LIKE 'Waiting to execute in isolation%');
---let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
---source include/wait_condition_with_debug.inc
-
-UNLOCK TABLES;
-
---let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND (STATE LIKE 'Waiting for table metadata lock%' OR STATE LIKE 'Waiting to execute in isolation%');
---let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
---source include/wait_condition_with_debug.inc
-
-COMMIT;
-SELECT COUNT(*) = 1 FROM t1;
+SELECT COUNT(*) AS EXPECT_2 FROM t1;
 
 --let $wsrep_local_bf_aborts_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
 
 --disable_query_log
---eval SELECT $wsrep_local_bf_aborts_after - $wsrep_local_bf_aborts_before = 0 AS wsrep_local_aborts_increment;
+--eval SELECT $wsrep_local_bf_aborts_after - $wsrep_local_bf_aborts_before AS wsrep_local_aborts_increment;
 --enable_query_log
 
 DROP TABLE t1;


### PR DESCRIPTION
Test case changes only. Original test case was expecting certain thd state but as this thd state might be overwritten test was not deterministic.

Fixed by using debug sync point in MDL code. When conflicting operation has started to wait conflicting MDL-lock to be released we stop it on sync point and make sure that conflicting LOCK TABLE is not BF aborted because of MDL-conflict.