### PR TITLE
MDEV-39798 : Galera test failure on galera_gcache_recover_manytrx

### DIFF
--- a/mysql-test/suite/galera/include/galera_wsrep_recover.inc
+++ b/mysql-test/suite/galera/include/galera_wsrep_recover.inc
@@ -10,15 +10,19 @@ if (!$wsrep_recover_additional)
 
 --perl
         use strict;
-        my $wsrep_start_position_str = "grep -a 'WSREP: Recovered position:' $ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'";
-        my $wsrep_start_position = `grep -a 'WSREP: Recovered position:' $ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'`;
+	my $file = "$ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log";
+	if (! -e $file) {
+          die "$file does not exists.";
+        }
+        my $wsrep_start_position = `grep -a 'WSREP: Recovered position:' $file | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'`;
         chomp($wsrep_start_position);
-
-        die if $wsrep_start_position eq '';
-
-        open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/galera_wsrep_start_position.inc") or die;
-        print FILE "--let \$galera_wsrep_start_position = $wsrep_start_position\n";
-        close FILE;
+	if ($wsrep_start_position eq '') {
+          die "No recovered position found $wsrep_start_position";
+        }
+        my $path = "$ENV{MYSQL_TMP_DIR}/galera_wsrep_start_position.inc";
+        open(FILE, ">", $path) or die "Can't open file: '$path' $!";
+        print FILE "--let \$galera_wsrep_start_position = $wsrep_start_position\n" or die "Write to '$path' failed $!";
+        close FILE or die "Closing $path failed $!";
 EOF
 
 --source $MYSQL_TMP_DIR/galera_wsrep_start_position.inc

--- a/mysql-test/suite/galera/r/galera_gcache_recover_full_gcache.result
+++ b/mysql-test/suite/galera/r/galera_gcache_recover_full_gcache.result
@@ -11,6 +11,8 @@ INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+COMMIT;
+set global innodb_log_checkpoint_now=ON;
 Killing server ...
 connection node_1;
 Performing --wsrep-recover ...
@@ -23,7 +25,6 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 5
 connection node_2;
-SET SESSION wsrep_sync_wait = 15;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 5

--- a/mysql-test/suite/galera/t/galera_gcache_recover.cnf
+++ b/mysql-test/suite/galera/t/galera_gcache_recover.cnf
@@ -2,6 +2,10 @@
 
 [mysqld.1]
 wsrep_provider_options='gcache.recover=yes;gcache.size=128M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;pc.wait_prim_timeout=PT60S'
+loose-galera-gcache-recover=1
+innodb_log_file_size=256M
 
 [mysqld.2]
 wsrep_provider_options='gcache.recover=yes;gcache.size=128M;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;pc.wait_prim_timeout=PT60S'
+loose-galera-gcache-recover=1
+innodb_log_file_size=256M

--- a/mysql-test/suite/galera/t/galera_gcache_recover.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover.test
@@ -5,6 +5,14 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/big_test.inc
+--source include/force_restart.inc
+
+# Remove if exists earlier log and start position, they might
+# be there if test using galera_wsrep_recover.inc failed
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_recover.log
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.log
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);

--- a/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.cnf
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.cnf
@@ -2,8 +2,11 @@
 
 [mysqld.1]
 max_allowed_packet=10M
-innodb_log_file_size=220M
+innodb_log_file_size=256M
 wsrep_provider_options='gcache.recover=yes;gcache.size=10M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;pc.wait_prim_timeout=PT60S'
+loose-galera-gcache-recover-full=1
 
 [mysqld.2]
 wsrep_provider_options='gcache.recover=yes;gcache.size=10M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;pc.wait_prim_timeout=PT60S'
+innodb_log_file_size=256M
+loose-galera-gcache-recover-full=1

--- a/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.test
@@ -5,6 +5,15 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/big_test.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# Remove if exists earlier log and start position, they might
+# be there if test using galera_wsrep_recover.inc failed
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_recover.log
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.log
 
 SET SESSION wsrep_sync_wait = 0;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 LONGBLOB) ENGINE=InnoDB;
@@ -27,6 +36,10 @@ INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+COMMIT;
+# Force checkpoint so that below select count is consistent
+set global innodb_log_checkpoint_now=ON;
+
 --source include/kill_galera.inc
 
 --connection node_1
@@ -45,12 +58,16 @@ INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 --connection node_1
 --source include/wait_until_connected_again.inc
 --source include/galera_wait_ready.inc
---let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1
+--source include/wait_condition.inc
 
 SELECT COUNT(*) FROM t1;
 
 --connection node_2
-SET SESSION wsrep_sync_wait = 15;
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1
+--source include/wait_condition.inc
 SELECT COUNT(*) FROM t1;
 
 --let $diff_servers = 1 2

--- a/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.cnf
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.cnf
@@ -1,9 +1,11 @@
 !include ../galera_2nodes.cnf
 
 [mysqld.1]
-innodb_log_file_size=220M
-wsrep_provider_options='gcache.recover=yes;gcache.size=128M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;pc.wait_prim_timeout=PT60S'
+innodb_log_file_size=256M
+wsrep_provider_options='gcache.recover=yes;gcache.size=256M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;pc.wait_prim_timeout=PT60S'
+loose-galera-gcache-recover-manytrx=1
 
 [mysqld.2]
-innodb_log_file_size=220M
-wsrep_provider_options='gcache.recover=yes;gcache.size=128M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;pc.wait_prim_timeout=PT60S'
+innodb_log_file_size=256M
+wsrep_provider_options='gcache.recover=yes;gcache.size=256M;pc.ignore_sb=true;repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;pc.wait_prim_timeout=PT60S'
+loose-galera-gcache-recover-manytrx=1

--- a/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.test
@@ -7,6 +7,14 @@
 --source include/big_test.inc
 --source include/have_innodb.inc
 --source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# Remove if exists earlier log and start position, they might
+# be there if test using galera_wsrep_recover.inc failed
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_recover.log
+--error 0,1,2
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.log
 
 SET SESSION wsrep_sync_wait = 0;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 LONGBLOB) ENGINE=InnoDB;


### PR DESCRIPTION
Problem was that file galera_wsrep_start_position.inc was not found and this could happen if one of the gcache recoverery tests are run concurently as the file is created and removed in included common file.

Avoid running these tests concurrently and force server restart by making configuration of the nodes different.